### PR TITLE
Remove leading "\""

### DIFF
--- a/dnsprovider/dnsprovider.go
+++ b/dnsprovider/dnsprovider.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/external-dns/endpoint"
@@ -302,6 +303,7 @@ func (p *DNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 			SetIdentifier: record.ID,
 			RecordTTL:     record.TTL,
 		})
+	}
 	return endpoints, nil
 }
 

--- a/dnsprovider/dnsprovider.go
+++ b/dnsprovider/dnsprovider.go
@@ -292,6 +292,9 @@ func (p *DNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 
 	var endpoints []*endpoint.Endpoint
 	for _, record := range records {
+		if record.RecordType == "TXT" {
+			record.Value = strings.Trim(record.Value, "\"")
+		}
 		endpoints = append(endpoints, &endpoint.Endpoint{
 			DNSName:       record.Key,
 			Targets:       []string{record.Value},
@@ -299,7 +302,6 @@ func (p *DNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error)
 			SetIdentifier: record.ID,
 			RecordTTL:     record.TTL,
 		})
-	}
 	return endpoints, nil
 }
 


### PR DESCRIPTION
The code change removes the "\"" as desired. Here's the new output of the records endpoint:

```
  {
    "dnsName": "k8s.cname-prom.porkboi.io",
    "targets": [
      "heritage=external-dns,external-dns/owner=default,external-dns/resource=ingress/monitoring/prometheus-kube-prometheus-prometheus"
    ],
    "recordType": "TXT",
    "setIdentifier": "6650be64b2b8464db0d16ad6"
  },
  ```
  
  However, we're still getting the error:
  
  ```
 Skipping endpoint alertmanager.porkboi.io 0 IN CNAME 6650be64b2b8464db0d16ab2 porkboi.io [] because owner id does not match, found: \"\", required: \"default\""
  ```

Still think this is good to add though, makes the output look much cleaner.
  