### PR TITLE
Handle cases where the provider isn't created by exiting cleanly.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -31,7 +31,7 @@ func main() {
 	config := configuration.Init()
 	provider, err := dnsprovider.Init(config)
 	if err != nil {
-		log.Error("failed to initialize provider", zap.Error(err))
+		log.Fatal("failed to initialize provider", zap.Error(err))
 	}
 
 	main, health := server.Init(config, webhook.New(provider))


### PR DESCRIPTION
Simply changes log.Error to log.Fatal which includes an `os.Exit(1)` as both http servers were still starting up when there was no provider to interact with.