### PR TITLE
Add support for using Local UniFi Api Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@
 
 ## ⛵ Deployment
 
-1. Create a local user with a password in your UniFi OS, this user only needs read/write access to the UniFi Network appliance.
+1. Open your network settings menu and go to `Settings > Control Plane > Admins & Users`.
 
-2. Add the ExternalDNS Helm repository to your cluster.
+2a. If you are running `UniFi Network v9.0.0` or greater, you can create an `Api Key` by selecting your user, going under `Control Plane API Key` and clicking `Create New`. Set the name to whatever you want, and the expiration to whatever you feel like commiting to. You can set `UNIFI_KEY` to this key.
+
+2b. Otherwise, create a local user with a password in your UniFi OS, this user only needs read/write access to the UniFi Network appliance.
+
+3. Add the ExternalDNS Helm repository to your cluster.
 
     ```sh
     helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
     ```
 
-3. Create a Kubernetes secret called `external-dns-unifi-secret` that holds `username` and `password` with their respected values from step 1.
+4. Create a Kubernetes secret called `external-dns-unifi-secret` that holds `username` and `password` with their respected values from step 1.
 
-4. Create the helm values file, for example `external-dns-unifi-values.yaml`:
+5. Create the helm values file, for example `external-dns-unifi-values.yaml`:
 
     ```yaml
     fullnameOverride: external-dns-unifi
@@ -80,7 +84,7 @@
     domainFilters: ["example.com"] # replace with your domain
     ```
 
-5. Install the Helm chart
+6. Install the Helm chart
 
     ```sh
     helm install external-dns-unifi external-dns/external-dns -f external-dns-unifi-values.yaml --version 1.14.3 -n external-dns
@@ -92,10 +96,11 @@
 
 | Environment Variable         | Description                                                  | Default Value |
 |------------------------------|--------------------------------------------------------------|---------------|
+| `UNIFI_KEY`                  | The local api key provided for your user                     | N/A           |
 | `UNIFI_USER`                 | Username for the Unifi Controller (must be provided).        | N/A           |
+| `UNIFI_PASS`                 | Password for the Unifi Controller (must be provided).        | N/A           |
 | `UNIFI_SKIP_TLS_VERIFY`      | Whether to skip TLS verification (true or false).            | `true`        |
 | `UNIFI_SITE`                 | Unifi Site Identifier (used in multi-site installations)     | `default`     |
-| `UNIFI_PASS`                 | Password for the Unifi Controller (must be provided).        | N/A           |
 | `UNIFI_HOST`                 | Host of the Unifi Controller (must be provided).             | N/A           |
 | `UNIFI_EXTERNAL_CONTROLLER`* | Toggles support for non-UniFi Hardware                       | `false`       |
 | `LOG_LEVEL`                  | Change the verbosity of logs (used when making a bug report) | `info`        |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## ⛵ Deployment
 
-1. Open your network settings menu and go to `Settings > Control Plane > Admins & Users`.
+1. Open your UniFi Console's Network Settings and go to `Settings > Control Plane > Admins & Users`.
 
 2a. If you are running `UniFi Network v9.0.0` or greater, you can create an `Api Key` by selecting your user, going under `Control Plane API Key` and clicking `Create New`. Set the name to whatever you want, and the expiration to whatever you feel like commiting to. You can set `UNIFI_KEY` to this key.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 1. Open your UniFi Console's Network Settings and go to `Settings > Control Plane > Admins & Users`.
 
-2a. If you are running `UniFi Network v9.0.0` or greater, you can create an `Api Key` by selecting your user, going under `Control Plane API Key` and clicking `Create New`. Set the name to whatever you want, and the expiration to whatever you feel like commiting to. You can set `UNIFI_KEY` to this key.
+2a. If you are running `UniFi Network v9.0.0` or greater, you can create an `Api Key` by selecting your user, going under `Control Plane API Key` and clicking `Create New`. Set the name to whatever you want, and the expiration to whatever you feel like commiting to. You can set `UNIFI_API_KEY` to this key.
 
 2b. Otherwise, create a local user with a password in your UniFi OS, this user only needs read/write access to the UniFi Network appliance.
 
@@ -33,7 +33,7 @@
     helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
     ```
 
-4. Create a Kubernetes secret called `external-dns-unifi-secret` that holds `username` and `password` with their respected values from step 1.
+4. Create a Kubernetes secret called `external-dns-unifi-secret` that holds either `api-key` or the `username` and `password` with their respected values from step 2.
 
 5. Create the helm values file, for example `external-dns-unifi-values.yaml`:
 
@@ -94,16 +94,16 @@
 
 ### Unifi Controller Configuration
 
-| Environment Variable         | Description                                                  | Default Value |
-|------------------------------|--------------------------------------------------------------|---------------|
-| `UNIFI_KEY`                  | The local api key provided for your user                     | N/A           |
-| `UNIFI_USER`                 | Username for the Unifi Controller (must be provided).        | N/A           |
-| `UNIFI_PASS`                 | Password for the Unifi Controller (must be provided).        | N/A           |
-| `UNIFI_SKIP_TLS_VERIFY`      | Whether to skip TLS verification (true or false).            | `true`        |
-| `UNIFI_SITE`                 | Unifi Site Identifier (used in multi-site installations)     | `default`     |
-| `UNIFI_HOST`                 | Host of the Unifi Controller (must be provided).             | N/A           |
-| `UNIFI_EXTERNAL_CONTROLLER`* | Toggles support for non-UniFi Hardware                       | `false`       |
-| `LOG_LEVEL`                  | Change the verbosity of logs (used when making a bug report) | `info`        |
+| Environment Variable         | Description                                                       | Default Value |
+|------------------------------|-------------------------------------------------------------------|---------------|
+| `UNIFI_API_KEY`              | The local api key provided for your user                          | N/A           |
+| `UNIFI_USER`                 | Username for the Unifi Controller (deprecated use `UNIFI_API_KEY`). | N/A           |
+| `UNIFI_PASS`                 | Password for the Unifi Controller (deprecated use `UNIFI_API_KEY`). | N/A           |
+| `UNIFI_SKIP_TLS_VERIFY`      | Whether to skip TLS verification (true or false).                 | `true`        |
+| `UNIFI_SITE`                 | Unifi Site Identifier (used in multi-site installations)          | `default`     |
+| `UNIFI_HOST`                 | Host of the Unifi Controller (must be provided).                  | N/A           |
+| `UNIFI_EXTERNAL_CONTROLLER`* | Toggles support for non-UniFi Hardware                            | `false`       |
+| `LOG_LEVEL`                  | Change the verbosity of logs (used when making a bug report)      | `info`        |
 
 *`UNIFI_EXTERNAL_CONTROLLER` is used to toggle between two versions of the Network Controller API. If you are running the UniFi software outside of UniFi's official hardware (e.g., Cloud Key or Dream Machine), you'll need to set `UNIFI_EXTERNAL_CONTROLLER` to `true`
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 <details>
 <summary>UniFi Api Key - Network v9.0.0+</summary>
 <br>
+
 1. Open your UniFi Console's Network Settings and go to `Settings > Control Plane > Admins & Users`.
 
 2. Selecting your user to operate under. Whenever we modify the DNS Records, this user will show up under `System Log > Admin Activity`
@@ -48,6 +49,7 @@ data:
 <details>
 <summary>Username & Password (Deprecated)</summary>
 <br>
+
 1. Open your UniFi Console's Network Settings and go to `Settings > Control Plane > Admins & Users`.
 
 2. Select `Create New Admin`.

--- a/cmd/webhook/init/log/log.go
+++ b/cmd/webhook/init/log/log.go
@@ -13,10 +13,10 @@ func Init() {
 
 	// Set the log format
 	format := os.Getenv("LOG_FORMAT")
-	if format == "test" {
-		config.Encoding = "console"
-	} else {
+	if format == "json" {
 		config.Encoding = "json"
+	} else {
+		config.Encoding = "console"
 	}
 
 	// Set the log level

--- a/cmd/webhook/init/log/log.go
+++ b/cmd/webhook/init/log/log.go
@@ -13,10 +13,10 @@ func Init() {
 
 	// Set the log format
 	format := os.Getenv("LOG_FORMAT")
-	if format == "json" {
-		config.Encoding = "json"
-	} else {
+	if format == "test" {
 		config.Encoding = "console"
+	} else {
+		config.Encoding = "json"
 	}
 
 	// Set the log level

--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -127,7 +127,7 @@ func (c *httpClient) doRequest(method, path string, body io.Reader) (*http.Respo
 	}
 
 	// TODO: Deprecation Notice - Use UNIFI_API_KEY instead
-	if c.Config.User != "" && c.Config.Password != "" {
+	if c.Config.ApiKey == "" {
 		if csrf := resp.Header.Get("X-CSRF-Token"); csrf != "" {
 			c.csrf = csrf
 		}

--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -206,7 +206,7 @@ func (c *httpClient) GetEndpoints() ([]DNSRecord, error) {
 		records[i].Port = nil
 	}
 
-	log.Debug("retrieved records", zap.Int("count", len(records)))
+	log.Debug("provider retrieved records", zap.Int("count", len(records)))
 	return records, nil
 }
 
@@ -251,6 +251,7 @@ func (c *httpClient) CreateEndpoint(endpoint *endpoint.Endpoint) (*DNSRecord, er
 		return nil, err
 	}
 
+	log.Debug("client created new record", zap.Any("record", &createdRecord))
 	return &createdRecord, nil
 }
 
@@ -272,6 +273,7 @@ func (c *httpClient) DeleteEndpoint(endpoint *endpoint.Endpoint) error {
 		return err
 	}
 
+	log.Debug("client deleted record", zap.Any("record", endpoint))
 	return nil
 }
 

--- a/internal/unifi/types.go
+++ b/internal/unifi/types.go
@@ -7,8 +7,9 @@ import (
 // Config represents the configuration for the UniFi API.
 type Config struct {
 	Host               string `env:"UNIFI_HOST,notEmpty"`
-	User               string `env:"UNIFI_USER,notEmpty"`
-	Password           string `env:"UNIFI_PASS,notEmpty"`
+	ApiKey             string `env:"UNIFI_KEY" envDefault:""`
+	User               string `env:"UNIFI_USER" envDefault:""`
+	Password           string `env:"UNIFI_PASS" envDefault:""`
 	Site               string `env:"UNIFI_SITE" envDefault:"default"`
 	ExternalController bool   `env:"UNIFI_EXTERNAL_CONTROLLER" envDefault:"false"`
 	SkipTLSVerify      bool   `env:"UNIFI_SKIP_TLS_VERIFY" envDefault:"true"`

--- a/internal/unifi/types.go
+++ b/internal/unifi/types.go
@@ -7,7 +7,7 @@ import (
 // Config represents the configuration for the UniFi API.
 type Config struct {
 	Host               string `env:"UNIFI_HOST,notEmpty"`
-	ApiKey             string `env:"UNIFI_KEY" envDefault:""`
+	ApiKey             string `env:"UNIFI_API_KEY" envDefault:""`
 	User               string `env:"UNIFI_USER" envDefault:""`
 	Password           string `env:"UNIFI_PASS" envDefault:""`
 	Site               string `env:"UNIFI_SITE" envDefault:"default"`

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -175,7 +175,7 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debug("adjust endpoints count", zap.Int("endpoints", len(pve)))
+	log.Debug("webhook adjust endpoints count", zap.Int("endpoints", len(pve)))
 	pve, err := p.provider.AdjustEndpoints(pve)
 	if err != nil {
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)


### PR DESCRIPTION
Closes #84

Adds support and prioritizes using `X-API-KEY` in requests instead of using CSRF tokens + cookies.

If testing well, username & password functionality *may* be phased out, but is unlikely to if users want a separate user to show up in logs as making dns changes.