### PR TITLE
feat(metrics): add provider label to all metrics for multi-instance filtering

### DIFF
--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -98,9 +98,9 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	}
 
 	// Record batch sizes
-	m.BatchSize.WithLabelValues("create").Observe(float64(len(changes.Create)))
-	m.BatchSize.WithLabelValues("update").Observe(float64(len(changes.UpdateNew)))
-	m.BatchSize.WithLabelValues("delete").Observe(float64(len(changes.Delete)))
+	m.BatchSize.WithLabelValues(metrics.ProviderName, "create").Observe(float64(len(changes.Create)))
+	m.BatchSize.WithLabelValues(metrics.ProviderName, "update").Observe(float64(len(changes.UpdateNew)))
+	m.BatchSize.WithLabelValues(metrics.ProviderName, "delete").Observe(float64(len(changes.Delete)))
 
 	// Process deletions and updates (delete old)
 	for _, endpoint := range append(changes.UpdateOld, changes.Delete...) {
@@ -125,7 +125,7 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 					continue
 				}
 
-				m.CNAMEConflictsTotal.Inc()
+				m.CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName).Inc()
 				if err := p.client.DeleteEndpoint(record); err != nil {
 					log.Error("failed to delete conflicting CNAME", zap.Any("data", record), zap.Error(err))
 					return errors.Wrapf(err, "failed to delete conflicting CNAME %s", record.DNSName)

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -35,8 +35,8 @@ func HTTPMetricsMiddleware(next http.Handler) http.Handler {
 		m := Get()
 
 		// Increment in-flight requests
-		m.HTTPRequestsInFlight.Inc()
-		defer m.HTTPRequestsInFlight.Dec()
+		m.HTTPRequestsInFlight.WithLabelValues(ProviderName).Inc()
+		defer m.HTTPRequestsInFlight.WithLabelValues(ProviderName).Dec()
 
 		// Wrap the response writer to capture status code and size
 		rw := newResponseWriter(w)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -56,7 +56,7 @@ func (p *Webhook) headerCheck(isContentType bool, w http.ResponseWriter, r *http
 	if len(header) == 0 {
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusNotAcceptable)
-		m.HTTPValidationErrorsTotal.WithLabelValues(headerType).Inc()
+		m.HTTPValidationErrorsTotal.WithLabelValues(metrics.ProviderName, headerType).Inc()
 
 		var msg string
 		if isContentType {
@@ -77,7 +77,7 @@ func (p *Webhook) headerCheck(isContentType bool, w http.ResponseWriter, r *http
 	if _, err := checkAndGetMediaTypeHeaderValue(header); err != nil {
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusUnsupportedMediaType)
-		m.HTTPValidationErrorsTotal.WithLabelValues(headerType).Inc()
+		m.HTTPValidationErrorsTotal.WithLabelValues(metrics.ProviderName, headerType).Inc()
 
 		msg := "client must provide a valid versioned media type in the "
 		if isContentType {
@@ -133,7 +133,7 @@ func (p *Webhook) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 	var changes plan.Changes
 	ctx := r.Context()
 	if err := json.NewDecoder(r.Body).Decode(&changes); err != nil {
-		m.HTTPJSONErrorsTotal.WithLabelValues("/records").Inc()
+		m.HTTPJSONErrorsTotal.WithLabelValues(metrics.ProviderName, "/records").Inc()
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusBadRequest)
 
@@ -163,7 +163,7 @@ func (p *Webhook) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 // AdjustEndpoints handles the post request for adjusting endpoints
 func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 	m := metrics.Get()
-	m.AdjustEndpointsTotal.Inc()
+	m.AdjustEndpointsTotal.WithLabelValues(metrics.ProviderName).Inc()
 
 	if err := p.contentTypeHeaderCheck(w, r); err != nil {
 		log.Error("content-type header check failed", zap.String("req_method", r.Method), zap.String("req_path", r.URL.Path))
@@ -176,7 +176,7 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 
 	var pve []*endpoint.Endpoint
 	if err := json.NewDecoder(r.Body).Decode(&pve); err != nil {
-		m.HTTPJSONErrorsTotal.WithLabelValues("/adjustendpoints").Inc()
+		m.HTTPJSONErrorsTotal.WithLabelValues(metrics.ProviderName, "/adjustendpoints").Inc()
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusBadRequest)
 
@@ -205,7 +205,7 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 
 func (p *Webhook) Negotiate(w http.ResponseWriter, r *http.Request) {
 	m := metrics.Get()
-	m.NegotiateTotal.Inc()
+	m.NegotiateTotal.WithLabelValues(metrics.ProviderName).Inc()
 
 	if err := p.acceptHeaderCheck(w, r); err != nil {
 		requestLog(r).With(zap.Error(err)).Error("accept header check failed")


### PR DESCRIPTION
## Summary

Add `provider` label to all Prometheus metrics for proper multi-instance filtering. This builds upon PR #135 by extending the provider label from just the info metric to all metrics.

Sorry for being late with this update - I realized after the initial PR was merged that the provider label should be on ALL metrics, not just the info metric. This enables proper filtering in multi-instance deployments where multiple webhook instances need to be distinguished.

## Changes

- Converted all `Counter`/`Gauge` types to `*CounterVec`/`*GaugeVec` to support labels
- Added `provider="unifi"` label to all metrics (HTTP, business, UniFi API, quality)
- Introduced `ProviderName` constant to avoid hardcoded strings throughout codebase
- Updated all `WithLabelValues()` calls across the codebase

## Technical Details

**Why *Vec types?**
- `Counter`/`Gauge` don't support labels - they're simple metrics
- `*CounterVec`/`*GaugeVec` are "vectors" of metrics distinguished by label combinations
- This is required for label-based filtering in Prometheus

**Affected files:**
- `pkg/metrics/metrics.go` - metric definitions and helper methods
- `pkg/metrics/middleware.go` - HTTP middleware
- `pkg/webhook/webhook.go` - webhook handlers
- `internal/unifi/client.go` - UniFi API client
- `internal/unifi/provider.go` - DNS provider

## Example Queries

With this change, Prometheus queries can now filter by provider:
```promql
externaldns_webhook_http_requests_total{provider="unifi"}
externaldns_webhook_unifi_api_duration_seconds{provider="unifi"}
rate(externaldns_webhook_changes_total{provider="unifi"}[5m])
```

## Test Plan

- [x] All tests pass
- [x] Project builds successfully
- [x] No compilation errors
- [x] Metrics remain functionally equivalent (just with additional label)