### PR TITLE
Fix container USER directive for Kubernetes runAsNonRoot compatibility

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,6 @@ COPY --from=builder /tmp/passwd /etc/passwd
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder --chmod=555 /build/webhook /external-dns-unifi-webhook
 
-USER nobody
+USER 65534
 EXPOSE 8888/tcp
 ENTRYPOINT ["/external-dns-unifi-webhook"]


### PR DESCRIPTION
## Summary

Fixed `runAsNonRoot` validation error in Kubernetes by changing `USER nobody` to `USER 65534` in Containerfile.

## Problem

Kubernetes with `runAsNonRoot: true` security context requires numeric UIDs to verify the user is non-root:
```
Error: container has runAsNonRoot and image has non-numeric user (nobody), 
cannot verify user is non-root
```

## Solution

- Changed `USER nobody` to `USER 65534` in Containerfile
- UID 65534 is the standard numeric ID for `nobody` user
- Kubernetes can now verify: `65534 != 0` ✅

## Test Plan

- Build container image
- Deploy to Kubernetes with `runAsNonRoot: true`
- Verify pod starts successfully

## Breaking Changes

None. Same user (nobody/65534), just explicit numeric UID.