### PR TITLE
fix(lint): resolve goconst and gosec findings across the codebase

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -305,7 +305,7 @@ func (c *httpClient) DeleteEndpoint(ctx context.Context, endpoint *externaldnsen
 
 func (c *httpClient) login(ctx context.Context) error {
 	m := metrics.Get()
-	jsonBody, err := json.Marshal(Login{
+	jsonBody, err := json.Marshal(Login{ //nolint:gosec // G117: login must marshal credentials to authenticate
 		Username: c.User,
 		Password: c.Password,
 		Remember: true,

--- a/internal/unifi/client_test.go
+++ b/internal/unifi/client_test.go
@@ -38,18 +38,18 @@ func TestGetEndpoints(t *testing.T) {
 			name: "successful fetch with A records",
 			responseBody: []DNSRecord{
 				{
-					ID:         "record1",
-					Key:        "test.example.com",
+					ID:         testDNSID1,
+					Key:        testDomain,
 					RecordType: recordTypeA,
-					Value:      "192.168.1.1",
+					Value:      testIPv4A,
 					TTL:        300,
 					Enabled:    true,
 				},
 				{
-					ID:         "record2",
+					ID:         testDNSID2,
 					Key:        "test2.example.com",
 					RecordType: recordTypeA,
-					Value:      "192.168.1.2",
+					Value:      testIPv4B,
 					TTL:        600,
 					Enabled:    true,
 				},
@@ -72,9 +72,9 @@ func TestGetEndpoints(t *testing.T) {
 			responseBody: []DNSRecord{
 				{
 					ID:         "srv1",
-					Key:        "_service._tcp.example.com",
+					Key:        testSRVName,
 					RecordType: recordTypeSRV,
-					Value:      "target.example.com",
+					Value:      testTarget,
 					TTL:        300,
 					Priority:   intPtr(10),
 					Weight:     intPtr(20),
@@ -118,7 +118,7 @@ func TestGetEndpoints(t *testing.T) {
 		},
 		{
 			name:           "HTTP 500 error",
-			responseBody:   UnifiErrorResponse{Code: "ERROR", Message: "Internal server error"},
+			responseBody:   UnifiErrorResponse{Code: testErrCode, Message: testMsgInternalServer},
 			responseStatus: http.StatusInternalServerError,
 			expectedLen:    0,
 			expectedErr:    true,
@@ -135,10 +135,10 @@ func TestGetEndpoints(t *testing.T) {
 					Enabled:    true,
 				},
 				{
-					ID:         "cname1",
+					ID:         testCNAMEID,
 					Key:        "cname.example.com",
 					RecordType: recordTypeCNAME,
-					Value:      "target.example.com",
+					Value:      testTarget,
 					TTL:        300,
 					Enabled:    true,
 				},
@@ -176,13 +176,13 @@ func TestGetEndpoints(t *testing.T) {
 			client := &httpClient{
 				Config: &Config{
 					Host:          server.URL,
-					Site:          "default",
-					APIKey:        "test-key",
+					Site:          testSite,
+					APIKey:        testKeyA,
 					SkipTLSVerify: true,
 				},
 				Client: server.Client(),
 				ClientURLs: &ClientURLs{
-					Records: "%s/v2/api/site/%s/static-dns/%s",
+					Records: unifiRecordPathExternal,
 				},
 			}
 
@@ -219,16 +219,16 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "create A record",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"test.example.com",
+				testDomain,
 				"A",
 				300,
-				"192.168.1.1",
+				testIPv4A,
 			),
 			responseBody: DNSRecord{
 				ID:         "new-record-1",
-				Key:        "test.example.com",
+				Key:        testDomain,
 				RecordType: recordTypeA,
-				Value:      "192.168.1.1",
+				Value:      testIPv4A,
 				TTL:        300,
 				Enabled:    true,
 			},
@@ -241,13 +241,13 @@ func TestCreateEndpoint(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to decode request body: %v", err)
 				}
-				if record.Key != "test.example.com" {
+				if record.Key != testDomain {
 					t.Errorf("Request Key = %q, want test.example.com", record.Key)
 				}
 				if record.RecordType != recordTypeA {
 					t.Errorf("Request RecordType = %q, want A", record.RecordType)
 				}
-				if record.Value != "192.168.1.1" {
+				if record.Value != testIPv4A {
 					t.Errorf("Request Value = %q, want 192.168.1.1", record.Value)
 				}
 			},
@@ -255,16 +255,16 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "create CNAME record",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"alias.example.com",
+				testAlias,
 				"CNAME",
 				600,
-				"target.example.com",
+				testTarget,
 			),
 			responseBody: DNSRecord{
 				ID:         "new-cname-1",
-				Key:        "alias.example.com",
+				Key:        testAlias,
 				RecordType: recordTypeCNAME,
-				Value:      "target.example.com",
+				Value:      testTarget,
 				TTL:        600,
 				Enabled:    true,
 			},
@@ -274,16 +274,16 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "create SRV record",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"_service._tcp.example.com",
+				testSRVName,
 				"SRV",
 				300,
 				"10 20 8080 target.example.com",
 			),
 			responseBody: DNSRecord{
 				ID:         "new-srv-1",
-				Key:        "_service._tcp.example.com",
+				Key:        testSRVName,
 				RecordType: recordTypeSRV,
-				Value:      "target.example.com",
+				Value:      testTarget,
 				TTL:        300,
 				Priority:   intPtr(10),
 				Weight:     intPtr(20),
@@ -313,7 +313,7 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "create multiple CNAME targets - uses only first",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"multi.example.com",
+				testMultiName,
 				"CNAME",
 				300,
 				"target1.example.com",
@@ -321,7 +321,7 @@ func TestCreateEndpoint(t *testing.T) {
 			),
 			responseBody: DNSRecord{
 				ID:         "new-record",
-				Key:        "multi.example.com",
+				Key:        testMultiName,
 				RecordType: recordTypeCNAME,
 				Value:      "target1.example.com",
 				TTL:        300,
@@ -333,10 +333,10 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "HTTP 400 error",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"test.example.com",
+				testDomain,
 				"A",
 				300,
-				"192.168.1.1",
+				testIPv4A,
 			),
 			responseBody:   UnifiErrorResponse{Code: "INVALID", Message: "Invalid record"},
 			responseStatus: http.StatusBadRequest,
@@ -345,7 +345,7 @@ func TestCreateEndpoint(t *testing.T) {
 		{
 			name: "invalid SRV format",
 			endpoint: endpoint.NewEndpointWithTTL(
-				"_service._tcp.example.com",
+				testSRVName,
 				"SRV",
 				300,
 				"invalid srv format",
@@ -371,13 +371,13 @@ func TestCreateEndpoint(t *testing.T) {
 			client := &httpClient{
 				Config: &Config{
 					Host:          server.URL,
-					Site:          "default",
-					APIKey:        "test-key",
+					Site:          testSite,
+					APIKey:        testKeyA,
 					SkipTLSVerify: true,
 				},
 				Client: server.Client(),
 				ClientURLs: &ClientURLs{
-					Records: "%s/v2/api/site/%s/static-dns/%s",
+					Records: unifiRecordPathExternal,
 				},
 			}
 
@@ -414,16 +414,16 @@ func TestDeleteEndpoint(t *testing.T) {
 		{
 			name: "delete single A record",
 			endpoint: endpoint.NewEndpoint(
-				"test.example.com",
+				testDomain,
 				"A",
-				"192.168.1.1",
+				testIPv4A,
 			),
 			existingRecords: []DNSRecord{
 				{
-					ID:         "record1",
-					Key:        "test.example.com",
+					ID:         testDNSID1,
+					Key:        testDomain,
 					RecordType: recordTypeA,
-					Value:      "192.168.1.1",
+					Value:      testIPv4A,
 					TTL:        300,
 					Enabled:    true,
 				},
@@ -435,23 +435,23 @@ func TestDeleteEndpoint(t *testing.T) {
 		{
 			name: "delete multiple A records with same name",
 			endpoint: endpoint.NewEndpoint(
-				"multi.example.com",
+				testMultiName,
 				"A",
 			),
 			existingRecords: []DNSRecord{
 				{
-					ID:         "record1",
-					Key:        "multi.example.com",
+					ID:         testDNSID1,
+					Key:        testMultiName,
 					RecordType: recordTypeA,
-					Value:      "192.168.1.1",
+					Value:      testIPv4A,
 					TTL:        300,
 					Enabled:    true,
 				},
 				{
-					ID:         "record2",
-					Key:        "multi.example.com",
+					ID:         testDNSID2,
+					Key:        testMultiName,
 					RecordType: recordTypeA,
-					Value:      "192.168.1.2",
+					Value:      testIPv4B,
 					TTL:        300,
 					Enabled:    true,
 				},
@@ -465,7 +465,7 @@ func TestDeleteEndpoint(t *testing.T) {
 			endpoint: endpoint.NewEndpoint(
 				"nonexistent.example.com",
 				"A",
-				"192.168.1.1",
+				testIPv4A,
 			),
 			existingRecords: []DNSRecord{},
 			responseStatus:  http.StatusOK,
@@ -475,16 +475,16 @@ func TestDeleteEndpoint(t *testing.T) {
 		{
 			name: "delete CNAME record",
 			endpoint: endpoint.NewEndpoint(
-				"alias.example.com",
+				testAlias,
 				"CNAME",
-				"target.example.com",
+				testTarget,
 			),
 			existingRecords: []DNSRecord{
 				{
-					ID:         "cname1",
-					Key:        "alias.example.com",
+					ID:         testCNAMEID,
+					Key:        testAlias,
 					RecordType: recordTypeCNAME,
-					Value:      "target.example.com",
+					Value:      testTarget,
 					TTL:        300,
 					Enabled:    true,
 				},
@@ -496,16 +496,16 @@ func TestDeleteEndpoint(t *testing.T) {
 		{
 			name: "HTTP 404 error on delete",
 			endpoint: endpoint.NewEndpoint(
-				"test.example.com",
+				testDomain,
 				"A",
-				"192.168.1.1",
+				testIPv4A,
 			),
 			existingRecords: []DNSRecord{
 				{
-					ID:         "record1",
-					Key:        "test.example.com",
+					ID:         testDNSID1,
+					Key:        testDomain,
 					RecordType: recordTypeA,
-					Value:      "192.168.1.1",
+					Value:      testIPv4A,
 					TTL:        300,
 					Enabled:    true,
 				},
@@ -531,7 +531,7 @@ func TestDeleteEndpoint(t *testing.T) {
 					w.WriteHeader(tt.responseStatus)
 					if tt.responseStatus != http.StatusOK {
 						_ = json.NewEncoder(w).Encode(UnifiErrorResponse{
-							Code:    "ERROR",
+							Code:    testErrCode,
 							Message: "Delete failed",
 						})
 					}
@@ -542,13 +542,13 @@ func TestDeleteEndpoint(t *testing.T) {
 			client := &httpClient{
 				Config: &Config{
 					Host:          server.URL,
-					Site:          "default",
-					APIKey:        "test-key",
+					Site:          testSite,
+					APIKey:        testKeyA,
 					SkipTLSVerify: true,
 				},
 				Client: server.Client(),
 				ClientURLs: &ClientURLs{
-					Records: "%s/v2/api/site/%s/static-dns/%s",
+					Records: unifiRecordPathExternal,
 				},
 			}
 
@@ -579,13 +579,13 @@ func TestSetHeaders(t *testing.T) {
 		{
 			name: "with API key",
 			config: &Config{
-				APIKey: "test-api-key",
+				APIKey: testKeyB,
 			},
 			csrf: "",
 			expectedHeaders: map[string]string{
-				"X-Api-Key":    "test-api-key",
-				"Accept":       "application/json",
-				"Content-Type": "application/json; charset=utf-8",
+				"X-Api-Key":       "test-api-key",
+				headerAccept:      contentTypeJSON,
+				headerContentType: contentTypeJSONUTF8,
 			},
 		},
 		{
@@ -593,11 +593,11 @@ func TestSetHeaders(t *testing.T) {
 			config: &Config{
 				APIKey: "",
 			},
-			csrf: "csrf-token-123",
+			csrf: testCSRF,
 			expectedHeaders: map[string]string{
-				"X-Csrf-Token": "csrf-token-123",
-				"Accept":       "application/json",
-				"Content-Type": "application/json; charset=utf-8",
+				"X-Csrf-Token":    testCSRF,
+				headerAccept:      contentTypeJSON,
+				headerContentType: contentTypeJSONUTF8,
 			},
 		},
 	}
@@ -636,21 +636,21 @@ func TestFormatURL_ClientUsage(t *testing.T) {
 		{
 			name: "internal controller - list records",
 			urls: &ClientURLs{
-				Records: "%s/proxy/network/v2/api/site/%s/static-dns/%s",
+				Records: unifiRecordPath,
 			},
-			host:      "https://192.168.1.1:8443",
-			site:      "default",
+			host:      testHostPort,
+			site:      testSite,
 			recordID:  "",
-			operation: "list",
+			operation: testOpList,
 			expected:  "https://192.168.1.1:8443/proxy/network/v2/api/site/default/static-dns/",
 		},
 		{
 			name: "internal controller - get specific record",
 			urls: &ClientURLs{
-				Records: "%s/proxy/network/v2/api/site/%s/static-dns/%s",
+				Records: unifiRecordPath,
 			},
-			host:      "https://192.168.1.1:8443",
-			site:      "default",
+			host:      testHostPort,
+			site:      testSite,
 			recordID:  "507f1f77bcf86cd799439011",
 			operation: "get",
 			expected:  "https://192.168.1.1:8443/proxy/network/v2/api/site/default/static-dns/507f1f77bcf86cd799439011",
@@ -658,12 +658,12 @@ func TestFormatURL_ClientUsage(t *testing.T) {
 		{
 			name: "external controller - list records",
 			urls: &ClientURLs{
-				Records: "%s/v2/api/site/%s/static-dns/%s",
+				Records: unifiRecordPathExternal,
 			},
-			host:      "https://ui.com",
+			host:      testHostExt,
 			site:      "site-abc123",
 			recordID:  "",
-			operation: "list",
+			operation: testOpList,
 			expected:  "https://ui.com/v2/api/site/site-abc123/static-dns/",
 		},
 	}

--- a/internal/unifi/consts_test.go
+++ b/internal/unifi/consts_test.go
@@ -1,0 +1,88 @@
+package unifi
+
+// Shared constants for the unifi package tests. These exist to satisfy the
+// goconst linter, which flags string literals repeated across the test files.
+const (
+	// Hosts and base URLs.
+	testHost       = "https://unifi.local"
+	testHostExt    = "https://ui.com"
+	testHostPort   = "https://192.168.1.1:8443"
+	testURLExample = "https://example.com"
+	testSite       = "default"
+	testRecordID   = "507f1f77bcf86cd799439011"
+
+	// DNS record field values.
+	testIPv4A   = "192.168.1.1"
+	testIPv4B   = "192.168.1.2"
+	testSRVName = "_service._tcp.example.com"
+	testAlias   = "alias.example.com"
+	testCNAMEID = "cname1"
+	testErrCode = "ERROR"
+
+	// HTTP headers.
+	headerAccept      = "Accept"
+	headerContentType = "Content-Type"
+	testCSRF          = "csrf-token-123"
+
+	// Error message fragments.
+	testMsgInternalServer = "Internal server error"
+	testMsgForbidden      = "forbidden"
+	testMsgRecordNotFound = "Record not found"
+	testMsgUnknownError   = "Unknown error"
+	testMsgGenericError   = "generic error"
+	testAuthFailedLogin   = "authentication failed during login"
+	testAPIErrPost        = "API error during POST"
+
+	// DataError data types.
+	testDataDNSRecord = "DNS record"
+	testDataAPIResp   = "API response"
+	testDataSRVTarget = "SRV record target"
+
+	// URLs used in error and FormatURL tests.
+	testURLLoginExample    = "https://unifi.example.com/api/login"
+	testURLInvalid         = "https://invalid.local/api"
+	testURLSpecialChars    = "https://unifi.local/api?param=value&key=секрет"
+	testURLMissingRecord   = "https://unifi.local/api/site/default/static-dns/missing"
+	testURLLoginInternal   = "https://unifi.local/api/auth/login"
+	testURLRecordsInternal = "https://unifi.local/proxy/network/v2/api/site/default/static-dns/"
+	testURLLoginExternal   = "https://ui.com/api/login"
+
+	// Subtest names.
+	testNameAuthError    = "AuthError"
+	testNameExtCtrlLogin = "external controller login"
+
+	// FormatURL path fragments.
+	testPathHostParam = "%s/api/%s"
+	testPathHost      = "%s/api"
+	testPathAPISlash  = "/api/"
+	testPathSingle    = "%s"
+	testPathTriple    = "%s%s%s"
+
+	// DNS record IDs, names and values.
+	testDNSID1    = "record1"
+	testDNSID2    = "record2"
+	testTarget    = "target.example.com"
+	testMultiName = "multi.example.com"
+
+	// Client credentials and content types.
+	testKeyA            = "test-key"
+	testKeyB            = "test-api-key"
+	contentTypeJSON     = "application/json"
+	contentTypeJSONUTF8 = "application/json; charset=utf-8"
+
+	// Operations, statuses and messages.
+	testOpList         = "list"
+	testOpMarshal      = "marshal"
+	testMsgInvalidAuth = "invalid credentials"
+	testMsgInvalid     = "invalid"
+	testMsgNoResponse  = "no response"
+	testStatus401      = "status 401"
+	testStatus0        = "status 0"
+	testDataRespBody   = "response body"
+
+	// Subtest names.
+	testNameNilError = "nil error"
+
+	// URL containing credentials, used to exercise FormatURL.
+	testURLCreds = "https://user:pass@example.com" //nolint:gosec // G101: test fixture URL with embedded credentials
+)

--- a/internal/unifi/errors_test.go
+++ b/internal/unifi/errors_test.go
@@ -24,27 +24,27 @@ func TestAuthError(t *testing.T) {
 	}{
 		{
 			name:       "auth error with wrapped error",
-			operation:  "login",
+			operation:  testOperationLogin,
 			status:     401,
-			message:    "invalid credentials",
+			message:    testMsgInvalidAuth,
 			wrappedErr: errors.New("connection timeout"),
 			expectedContain: []string{
-				"authentication failed during login",
-				"status 401",
-				"invalid credentials",
+				testAuthFailedLogin,
+				testStatus401,
+				testMsgInvalidAuth,
 				"connection timeout",
 			},
 		},
 		{
 			name:       "auth error without wrapped error",
-			operation:  "login",
+			operation:  testOperationLogin,
 			status:     403,
-			message:    "forbidden",
+			message:    testMsgForbidden,
 			wrappedErr: nil,
 			expectedContain: []string{
-				"authentication failed during login",
+				testAuthFailedLogin,
 				"status 403",
-				"forbidden",
+				testMsgForbidden,
 			},
 		},
 		{
@@ -55,31 +55,31 @@ func TestAuthError(t *testing.T) {
 			wrappedErr: nil,
 			expectedContain: []string{
 				"authentication failed during refresh",
-				"status 401",
+				testStatus401,
 			},
 		},
 		{
 			name:       "auth error with status 0",
 			operation:  "verify",
 			status:     0,
-			message:    "no response",
+			message:    testMsgNoResponse,
 			wrappedErr: nil,
 			expectedContain: []string{
 				"authentication failed during verify",
-				"status 0",
-				"no response",
+				testStatus0,
+				testMsgNoResponse,
 			},
 		},
 		{
 			name:       "auth error with negative status",
 			operation:  "test",
 			status:     -1,
-			message:    "invalid",
+			message:    testMsgInvalid,
 			wrappedErr: nil,
 			expectedContain: []string{
 				"authentication failed during test",
 				"status -1",
-				"invalid",
+				testMsgInvalid,
 			},
 		},
 	}
@@ -127,29 +127,29 @@ func TestNetworkError(t *testing.T) {
 	}{
 		{
 			name:       "network error with connection timeout",
-			operation:  "GET",
-			url:        "https://unifi.example.com/api/login",
+			operation:  http.MethodGet,
+			url:        testURLLoginExample,
 			wrappedErr: errors.New("dial tcp: connection timeout"),
 			expectedContain: []string{
 				"network error during GET",
-				"https://unifi.example.com/api/login",
+				testURLLoginExample,
 				"dial tcp: connection timeout",
 			},
 		},
 		{
 			name:       "network error with DNS failure",
-			operation:  "POST",
-			url:        "https://invalid.local/api",
+			operation:  http.MethodPost,
+			url:        testURLInvalid,
 			wrappedErr: errors.New("no such host"),
 			expectedContain: []string{
 				"network error during POST",
-				"https://invalid.local/api",
+				testURLInvalid,
 				"no such host",
 			},
 		},
 		{
 			name:       "network error with empty URL",
-			operation:  "DELETE",
+			operation:  http.MethodDelete,
 			url:        "",
 			wrappedErr: errors.New("empty URL"),
 			expectedContain: []string{
@@ -160,11 +160,11 @@ func TestNetworkError(t *testing.T) {
 		{
 			name:       "network error with special characters in URL",
 			operation:  "PUT",
-			url:        "https://unifi.local/api?param=value&key=секрет",
+			url:        testURLSpecialChars,
 			wrappedErr: errors.New("invalid character"),
 			expectedContain: []string{
 				"network error during PUT",
-				"https://unifi.local/api?param=value&key=секрет",
+				testURLSpecialChars,
 				"invalid character",
 			},
 		},
@@ -211,32 +211,32 @@ func TestAPIError(t *testing.T) {
 	}{
 		{
 			name:       "API error 404",
-			operation:  "GET",
-			url:        "https://unifi.local/api/site/default/static-dns/missing",
+			operation:  http.MethodGet,
+			url:        testURLMissingRecord,
 			statusCode: 404,
-			message:    "Record not found",
+			message:    testMsgRecordNotFound,
 			expectedContain: []string{
 				"API error during GET",
-				"https://unifi.local/api/site/default/static-dns/missing",
+				testURLMissingRecord,
 				"status 404",
-				"Record not found",
+				testMsgRecordNotFound,
 			},
 		},
 		{
 			name:       "API error 500",
-			operation:  "POST",
+			operation:  http.MethodPost,
 			url:        "https://unifi.local/api/login",
 			statusCode: 500,
-			message:    "Internal server error",
+			message:    testMsgInternalServer,
 			expectedContain: []string{
-				"API error during POST",
+				testAPIErrPost,
 				"status 500",
-				"Internal server error",
+				testMsgInternalServer,
 			},
 		},
 		{
 			name:       "API error with empty message",
-			operation:  "DELETE",
+			operation:  http.MethodDelete,
 			url:        "https://unifi.local/api/record/123",
 			statusCode: 400,
 			message:    "",
@@ -250,21 +250,21 @@ func TestAPIError(t *testing.T) {
 			operation:  "PATCH",
 			url:        "https://unifi.local/api",
 			statusCode: 0,
-			message:    "Unknown error",
+			message:    testMsgUnknownError,
 			expectedContain: []string{
 				"API error during PATCH",
-				"status 0",
-				"Unknown error",
+				testStatus0,
+				testMsgUnknownError,
 			},
 		},
 		{
 			name:       "API error with long message",
-			operation:  "POST",
+			operation:  http.MethodPost,
 			url:        "https://unifi.local/api/dns",
 			statusCode: 422,
 			message:    strings.Repeat("Very long error message with lots of details. ", 10),
 			expectedContain: []string{
-				"API error during POST",
+				testAPIErrPost,
 				"status 422",
 				"Very long error message",
 			},
@@ -301,45 +301,45 @@ func TestDataError(t *testing.T) {
 	}{
 		{
 			name:       "data error marshaling JSON",
-			operation:  "marshal",
-			dataType:   "DNS record",
+			operation:  testOpMarshal,
+			dataType:   testDataDNSRecord,
 			wrappedErr: errors.New("json: unsupported type"),
 			expectedContain: []string{
 				"data error during marshal",
-				"DNS record",
+				testDataDNSRecord,
 				"json: unsupported type",
 			},
 		},
 		{
 			name:       "data error unmarshaling JSON",
 			operation:  "unmarshal",
-			dataType:   "API response",
+			dataType:   testDataAPIResp,
 			wrappedErr: errors.New("json: cannot unmarshal"),
 			expectedContain: []string{
 				"data error during unmarshal",
-				"API response",
+				testDataAPIResp,
 				"json: cannot unmarshal",
 			},
 		},
 		{
 			name:       "data error reading body",
 			operation:  "read",
-			dataType:   "response body",
+			dataType:   testDataRespBody,
 			wrappedErr: errors.New("unexpected EOF"),
 			expectedContain: []string{
 				"data error during read",
-				"response body",
+				testDataRespBody,
 				"unexpected EOF",
 			},
 		},
 		{
 			name:       "data error parsing SRV record",
 			operation:  "parse",
-			dataType:   "SRV record target",
+			dataType:   testDataSRVTarget,
 			wrappedErr: errors.New("invalid format"),
 			expectedContain: []string{
 				"data error during parse",
-				"SRV record target",
+				testDataSRVTarget,
 				"invalid format",
 			},
 		},
@@ -387,7 +387,7 @@ func TestDataError(t *testing.T) {
 // TestNewAuthError tests NewAuthError helper.
 func TestNewAuthError(t *testing.T) {
 	wrappedErr := errors.New("underlying error")
-	err := NewAuthError("login", 401, "unauthorized", wrappedErr)
+	err := NewAuthError(testOperationLogin, 401, "unauthorized", wrappedErr)
 
 	if err == nil {
 		t.Fatal("NewAuthError returned nil")
@@ -416,7 +416,7 @@ func TestNewAuthError(t *testing.T) {
 // TestNewNetworkError tests NewNetworkError helper.
 func TestNewNetworkError(t *testing.T) {
 	wrappedErr := errors.New("connection refused")
-	err := NewNetworkError("POST", "https://example.com", wrappedErr)
+	err := NewNetworkError(http.MethodPost, testURLExample, wrappedErr)
 
 	if err == nil {
 		t.Fatal("NewNetworkError returned nil")
@@ -428,11 +428,11 @@ func TestNewNetworkError(t *testing.T) {
 		t.Fatalf("NewNetworkError returned %T, want *NetworkError", err)
 	}
 
-	if netErr.Operation != "POST" {
-		t.Errorf("Operation = %q, want %q", netErr.Operation, "POST")
+	if netErr.Operation != http.MethodPost {
+		t.Errorf("Operation = %q, want %q", netErr.Operation, http.MethodPost)
 	}
-	if netErr.URL != "https://example.com" {
-		t.Errorf("URL = %q, want %q", netErr.URL, "https://example.com")
+	if netErr.URL != testURLExample {
+		t.Errorf("URL = %q, want %q", netErr.URL, testURLExample)
 	}
 	if !errors.Is(netErr.Err, wrappedErr) {
 		t.Errorf("Err = %v, want %v", netErr.Err, wrappedErr)
@@ -441,7 +441,7 @@ func TestNewNetworkError(t *testing.T) {
 
 // TestNewAPIError tests NewAPIError helper.
 func TestNewAPIError(t *testing.T) {
-	err := NewAPIError("GET", "https://api.example.com", 404, "not found")
+	err := NewAPIError(http.MethodGet, "https://api.example.com", 404, "not found")
 
 	if err == nil {
 		t.Fatal("NewAPIError returned nil")
@@ -453,8 +453,8 @@ func TestNewAPIError(t *testing.T) {
 		t.Fatalf("NewAPIError returned %T, want *APIError", err)
 	}
 
-	if apiErr.Operation != "GET" {
-		t.Errorf("Operation = %q, want %q", apiErr.Operation, "GET")
+	if apiErr.Operation != http.MethodGet {
+		t.Errorf("Operation = %q, want %q", apiErr.Operation, http.MethodGet)
 	}
 	if apiErr.URL != "https://api.example.com" {
 		t.Errorf("URL = %q, want %q", apiErr.URL, "https://api.example.com")
@@ -470,7 +470,7 @@ func TestNewAPIError(t *testing.T) {
 // TestNewDataError tests NewDataError helper.
 func TestNewDataError(t *testing.T) {
 	wrappedErr := errors.New("json error")
-	err := NewDataError("marshal", "user data", wrappedErr)
+	err := NewDataError(testOpMarshal, "user data", wrappedErr)
 
 	if err == nil {
 		t.Fatal("NewDataError returned nil")
@@ -482,8 +482,8 @@ func TestNewDataError(t *testing.T) {
 		t.Fatalf("NewDataError returned %T, want *DataError", err)
 	}
 
-	if dataErr.Operation != "marshal" {
-		t.Errorf("Operation = %q, want %q", dataErr.Operation, "marshal")
+	if dataErr.Operation != testOpMarshal {
+		t.Errorf("Operation = %q, want %q", dataErr.Operation, testOpMarshal)
 	}
 	if dataErr.DataType != "user data" {
 		t.Errorf("DataType = %q, want %q", dataErr.DataType, "user data")
@@ -502,26 +502,26 @@ func TestIsAuthError(t *testing.T) {
 	}{
 		{
 			name:     "actual AuthError",
-			err:      NewAuthError("login", 401, "fail", nil),
+			err:      NewAuthError(testOperationLogin, 401, "fail", nil),
 			expected: true,
 		},
 		{
 			name:     "wrapped AuthError",
-			err:      errors.Wrap(NewAuthError("login", 401, "fail", nil), "additional context"),
+			err:      errors.Wrap(NewAuthError(testOperationLogin, 401, "fail", nil), "additional context"),
 			expected: true,
 		},
 		{
 			name:     "NetworkError",
-			err:      NewNetworkError("GET", "url", errors.New("error")),
+			err:      NewNetworkError(http.MethodGet, "url", errors.New("error")),
 			expected: false,
 		},
 		{
-			name:     "generic error",
+			name:     testMsgGenericError,
 			err:      errors.New("some error"),
 			expected: false,
 		},
 		{
-			name:     "nil error",
+			name:     testNameNilError,
 			err:      nil,
 			expected: false,
 		},
@@ -546,26 +546,26 @@ func TestIsNetworkError(t *testing.T) {
 	}{
 		{
 			name:     "actual NetworkError",
-			err:      NewNetworkError("GET", "url", errors.New("error")),
+			err:      NewNetworkError(http.MethodGet, "url", errors.New("error")),
 			expected: true,
 		},
 		{
 			name:     "wrapped NetworkError",
-			err:      errors.Wrap(NewNetworkError("GET", "url", errors.New("error")), "context"),
+			err:      errors.Wrap(NewNetworkError(http.MethodGet, "url", errors.New("error")), "context"),
 			expected: true,
 		},
 		{
-			name:     "AuthError",
-			err:      NewAuthError("login", 401, "fail", nil),
+			name:     testNameAuthError,
+			err:      NewAuthError(testOperationLogin, 401, "fail", nil),
 			expected: false,
 		},
 		{
-			name:     "generic error",
+			name:     testMsgGenericError,
 			err:      errors.New("some error"),
 			expected: false,
 		},
 		{
-			name:     "nil error",
+			name:     testNameNilError,
 			err:      nil,
 			expected: false,
 		},
@@ -590,26 +590,26 @@ func TestIsAPIError(t *testing.T) {
 	}{
 		{
 			name:     "actual APIError",
-			err:      NewAPIError("GET", "url", 404, "not found"),
+			err:      NewAPIError(http.MethodGet, "url", 404, "not found"),
 			expected: true,
 		},
 		{
 			name:     "wrapped APIError",
-			err:      errors.Wrap(NewAPIError("GET", "url", 404, "not found"), "context"),
+			err:      errors.Wrap(NewAPIError(http.MethodGet, "url", 404, "not found"), "context"),
 			expected: true,
 		},
 		{
-			name:     "AuthError",
-			err:      NewAuthError("login", 401, "fail", nil),
+			name:     testNameAuthError,
+			err:      NewAuthError(testOperationLogin, 401, "fail", nil),
 			expected: false,
 		},
 		{
-			name:     "generic error",
+			name:     testMsgGenericError,
 			err:      errors.New("some error"),
 			expected: false,
 		},
 		{
-			name:     "nil error",
+			name:     testNameNilError,
 			err:      nil,
 			expected: false,
 		},
@@ -634,26 +634,26 @@ func TestIsDataError(t *testing.T) {
 	}{
 		{
 			name:     "actual DataError",
-			err:      NewDataError("marshal", "data", errors.New("error")),
+			err:      NewDataError(testOpMarshal, "data", errors.New("error")),
 			expected: true,
 		},
 		{
 			name:     "wrapped DataError",
-			err:      errors.Wrap(NewDataError("marshal", "data", errors.New("error")), "context"),
+			err:      errors.Wrap(NewDataError(testOpMarshal, "data", errors.New("error")), "context"),
 			expected: true,
 		},
 		{
-			name:     "AuthError",
-			err:      NewAuthError("login", 401, "fail", nil),
+			name:     testNameAuthError,
+			err:      NewAuthError(testOperationLogin, 401, "fail", nil),
 			expected: false,
 		},
 		{
-			name:     "generic error",
+			name:     testMsgGenericError,
 			err:      errors.New("some error"),
 			expected: false,
 		},
 		{
-			name:     "nil error",
+			name:     testNameNilError,
 			err:      nil,
 			expected: false,
 		},
@@ -695,7 +695,7 @@ func TestErrorChaining(t *testing.T) {
 
 // TestErrorAs tests errors.As with custom error types.
 func TestErrorAs(t *testing.T) {
-	authErr := NewAuthError("login", 401, "unauthorized", nil)
+	authErr := NewAuthError(testOperationLogin, 401, "unauthorized", nil)
 	wrappedErr := errors.Wrap(authErr, "wrapped")
 
 	var targetErr *AuthError
@@ -703,8 +703,8 @@ func TestErrorAs(t *testing.T) {
 		t.Fatal("errors.As failed to extract AuthError")
 	}
 
-	if targetErr.Operation != "login" {
-		t.Errorf("extracted AuthError has Operation = %q, want %q", targetErr.Operation, "login")
+	if targetErr.Operation != testOperationLogin {
+		t.Errorf("extracted AuthError has Operation = %q, want %q", targetErr.Operation, testOperationLogin)
 	}
 	if targetErr.Status != 401 {
 		t.Errorf("extracted AuthError has Status = %d, want %d", targetErr.Status, 401)

--- a/internal/unifi/utils_test.go
+++ b/internal/unifi/utils_test.go
@@ -14,157 +14,157 @@ func TestFormatURL(t *testing.T) {
 		{
 			name:     "login path",
 			path:     "%s/api/auth/login",
-			params:   []string{"https://unifi.local"},
-			expected: "https://unifi.local/api/auth/login",
+			params:   []string{testHost},
+			expected: testURLLoginInternal,
 		},
 		{
 			name:     "records path with site",
-			path:     "%s/proxy/network/v2/api/site/%s/static-dns/%s",
-			params:   []string{"https://unifi.local", "default"},
-			expected: "https://unifi.local/proxy/network/v2/api/site/default/static-dns/",
+			path:     unifiRecordPath,
+			params:   []string{testHost, testSite},
+			expected: testURLRecordsInternal,
 		},
 		{
 			name:     "records path with site and record ID",
-			path:     "%s/proxy/network/v2/api/site/%s/static-dns/%s",
-			params:   []string{"https://unifi.local", "default", "abc123"},
+			path:     unifiRecordPath,
+			params:   []string{testHost, testSite, "abc123"},
 			expected: "https://unifi.local/proxy/network/v2/api/site/default/static-dns/abc123",
 		},
 		{
 			name:     "external controller login",
-			path:     "%s/api/login",
-			params:   []string{"https://ui.com"},
+			path:     unifiLoginPathExternal,
+			params:   []string{testHostExt},
 			expected: "https://ui.com/api/login",
 		},
 		{
 			name:     "external controller records",
-			path:     "%s/v2/api/site/%s/static-dns/%s",
-			params:   []string{"https://ui.com", "site-id", "record-id"},
+			path:     unifiRecordPathExternal,
+			params:   []string{testHostExt, "site-id", "record-id"},
 			expected: "https://ui.com/v2/api/site/site-id/static-dns/record-id",
 		},
 		{
 			name:     "no placeholders - appends params",
 			path:     "/api/login",
-			params:   []string{"https://example.com"},
+			params:   []string{testURLExample},
 			expected: "/api/loginhttps://example.com",
 		},
 		{
 			name:     "empty params",
-			path:     "%s/api/%s",
+			path:     testPathHostParam,
 			params:   []string{},
-			expected: "/api/",
+			expected: testPathAPISlash,
 		},
 		{
 			name:     "empty string params",
 			path:     "%s/api/%s/data",
-			params:   []string{"https://example.com", ""},
+			params:   []string{testURLExample, ""},
 			expected: "https://example.com/api//data",
 		},
 		{
 			name:     "more placeholders than params",
 			path:     "%s/api/%s/site/%s",
-			params:   []string{"https://example.com"},
+			params:   []string{testURLExample},
 			expected: "https://example.com/api//site/",
 		},
 		{
 			name:     "URL with port",
-			path:     "%s/api/login",
+			path:     unifiLoginPathExternal,
 			params:   []string{"https://unifi.local:8443"},
 			expected: "https://unifi.local:8443/api/login",
 		},
 		{
 			name:     "URL with query params",
 			path:     "%s/api/site/%s?filter=active",
-			params:   []string{"https://unifi.local", "default"},
+			params:   []string{testHost, testSite},
 			expected: "https://unifi.local/api/site/default?filter=active",
 		},
 		{
 			name:     "special characters in params",
-			path:     "%s/api/%s",
-			params:   []string{"https://example.com", "special-chars_123"},
+			path:     testPathHostParam,
+			params:   []string{testURLExample, "special-chars_123"},
 			expected: "https://example.com/api/special-chars_123",
 		},
 		{
 			name:     "unicode in params",
-			path:     "%s/api/%s",
+			path:     testPathHostParam,
 			params:   []string{"https://пример.рф", "сайт"},
 			expected: "https://пример.рф/api/сайт",
 		},
 		{
 			name:     "empty path - appends params",
 			path:     "",
-			params:   []string{"https://example.com"},
-			expected: "https://example.com",
+			params:   []string{testURLExample},
+			expected: testURLExample,
 		},
 		{
 			name:     "single placeholder",
-			path:     "%s",
-			params:   []string{"https://example.com"},
-			expected: "https://example.com",
+			path:     testPathSingle,
+			params:   []string{testURLExample},
+			expected: testURLExample,
 		},
 		{
 			name:     "consecutive placeholders",
-			path:     "%s%s%s",
+			path:     testPathTriple,
 			params:   []string{"a", "b", "c"},
 			expected: "abc",
 		},
 		{
 			name:     "path with trailing slash",
 			path:     "%s/api/%s/",
-			params:   []string{"https://example.com", "v1"},
+			params:   []string{testURLExample, "v1"},
 			expected: "https://example.com/api/v1/",
 		},
 		{
 			name:     "path with multiple slashes",
 			path:     "%s//api//%s",
-			params:   []string{"https://example.com", "endpoint"},
+			params:   []string{testURLExample, "endpoint"},
 			expected: "https://example.com//api//endpoint",
 		},
 		{
 			name:     "nil params equivalent",
-			path:     "%s/api/%s",
+			path:     testPathHostParam,
 			params:   nil,
-			expected: "/api/",
+			expected: testPathAPISlash,
 		},
 		{
 			name:     "IPv4 address",
-			path:     "%s/api/login",
+			path:     unifiLoginPathExternal,
 			params:   []string{"https://192.168.1.1"},
 			expected: "https://192.168.1.1/api/login",
 		},
 		{
 			name:     "IPv6 address",
-			path:     "%s/api/login",
+			path:     unifiLoginPathExternal,
 			params:   []string{"https://[2001:db8::1]"},
 			expected: "https://[2001:db8::1]/api/login",
 		},
 		{
 			name:     "path injection attempt",
-			path:     "%s/api/%s",
-			params:   []string{"https://example.com", "../../../etc/passwd"},
+			path:     testPathHostParam,
+			params:   []string{testURLExample, "../../../etc/passwd"},
 			expected: "https://example.com/api/../../../etc/passwd",
 		},
 		{
 			name:     "URL with fragment",
 			path:     "%s/api/%s#section",
-			params:   []string{"https://example.com", "resource"},
+			params:   []string{testURLExample, "resource"},
 			expected: "https://example.com/api/resource#section",
 		},
 		{
 			name:     "URL with credentials",
-			path:     "%s/api",
-			params:   []string{"https://user:pass@example.com"},
-			expected: "https://user:pass@example.com/api",
+			path:     testPathHost,
+			params:   []string{testURLCreds},
+			expected: testURLCreds + "/api",
 		},
 		{
 			name:     "long record ID",
 			path:     "%s/api/site/%s/static-dns/%s",
-			params:   []string{"https://example.com", "default", "abcdef0123456789abcdef0123456789abcdef01"},
+			params:   []string{testURLExample, testSite, "abcdef0123456789abcdef0123456789abcdef01"},
 			expected: "https://example.com/api/site/default/static-dns/abcdef0123456789abcdef0123456789abcdef01",
 		},
 		{
 			name:     "whitespace in params",
-			path:     "%s/api/%s",
-			params:   []string{"https://example.com", "my site"},
+			path:     testPathHostParam,
+			params:   []string{testURLExample, "my site"},
 			expected: "https://example.com/api/my site",
 		},
 	}
@@ -181,16 +181,6 @@ func TestFormatURL(t *testing.T) {
 
 // TestFormatURLRealWorldUsage tests actual usage patterns from the codebase.
 func TestFormatURLRealWorldUsage(t *testing.T) {
-	const (
-		host                    = "https://unifi.local"
-		site                    = "default"
-		recordID                = "507f1f77bcf86cd799439011"
-		unifiLoginPath          = "%s/api/auth/login"
-		unifiLoginPathExternal  = "%s/api/login"
-		unifiRecordPath         = "%s/proxy/network/v2/api/site/%s/static-dns/%s"
-		unifiRecordPathExternal = "%s/v2/api/site/%s/static-dns/%s"
-	)
-
 	tests := []struct {
 		name     string
 		path     string
@@ -200,49 +190,49 @@ func TestFormatURLRealWorldUsage(t *testing.T) {
 		{
 			name:     "internal controller login",
 			path:     unifiLoginPath,
-			params:   []string{host},
-			expected: "https://unifi.local/api/auth/login",
+			params:   []string{testHost},
+			expected: testURLLoginInternal,
 		},
 		{
-			name:     "external controller login",
+			name:     testNameExtCtrlLogin,
 			path:     unifiLoginPathExternal,
-			params:   []string{"https://ui.com"},
-			expected: "https://ui.com/api/login",
+			params:   []string{testHostExt},
+			expected: testURLLoginExternal,
 		},
 		{
 			name:     "get all records (internal)",
 			path:     unifiRecordPath,
-			params:   []string{host, site},
-			expected: "https://unifi.local/proxy/network/v2/api/site/default/static-dns/",
+			params:   []string{testHost, testSite},
+			expected: testURLRecordsInternal,
 		},
 		{
 			name:     "get specific record (internal)",
 			path:     unifiRecordPath,
-			params:   []string{host, site, recordID},
+			params:   []string{testHost, testSite, testRecordID},
 			expected: "https://unifi.local/proxy/network/v2/api/site/default/static-dns/507f1f77bcf86cd799439011",
 		},
 		{
 			name:     "get all records (external)",
 			path:     unifiRecordPathExternal,
-			params:   []string{"https://ui.com", site},
+			params:   []string{testHostExt, testSite},
 			expected: "https://ui.com/v2/api/site/default/static-dns/",
 		},
 		{
 			name:     "get specific record (external)",
 			path:     unifiRecordPathExternal,
-			params:   []string{"https://ui.com", site, recordID},
+			params:   []string{testHostExt, testSite, testRecordID},
 			expected: "https://ui.com/v2/api/site/default/static-dns/507f1f77bcf86cd799439011",
 		},
 		{
 			name:     "custom site name",
 			path:     unifiRecordPath,
-			params:   []string{host, "my-custom-site"},
+			params:   []string{testHost, "my-custom-site"},
 			expected: "https://unifi.local/proxy/network/v2/api/site/my-custom-site/static-dns/",
 		},
 		{
 			name:     "controller with port",
 			path:     unifiLoginPath,
-			params:   []string{"https://192.168.1.1:8443"},
+			params:   []string{testHostPort},
 			expected: "https://192.168.1.1:8443/api/auth/login",
 		},
 	}
@@ -267,8 +257,8 @@ func TestFormatURLEdgeCases(t *testing.T) {
 	}{
 		{
 			name:     "extremely long URL",
-			path:     "%s/api/%s",
-			params:   []string{"https://example.com", string(make([]byte, 10000))},
+			path:     testPathHostParam,
+			params:   []string{testURLExample, string(make([]byte, 10000))},
 			expected: "https://example.com/api/" + string(make([]byte, 10000)),
 		},
 		{
@@ -279,7 +269,7 @@ func TestFormatURLEdgeCases(t *testing.T) {
 		},
 		{
 			name:     "only placeholders",
-			path:     "%s%s%s",
+			path:     testPathTriple,
 			params:   []string{"", "", ""},
 			expected: "",
 		},
@@ -317,7 +307,7 @@ func TestFormatURLPanic(t *testing.T) {
 		{
 			name:   "more params than placeholders - causes panic",
 			path:   "%s/api",
-			params: []string{"https://example.com", "extra", "params"},
+			params: []string{testURLExample, "extra", "params"},
 		},
 		{
 			name:   "three extra params",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -13,6 +13,13 @@ const (
 	ProviderName = "unifi"
 
 	histogramBucketCount = 8
+
+	// Prometheus label names reused across metric definitions.
+	labelProvider   = "provider"
+	labelEndpoint   = "endpoint"
+	labelRecordType = "record_type"
+	labelOperation  = "operation"
+	labelMethod     = "method"
 )
 
 // Metrics holds all Prometheus metrics for the webhook.
@@ -74,7 +81,7 @@ func New(version string) *Metrics {
 				Name:      "http_requests_total",
 				Help:      "Total number of HTTP requests",
 			},
-			[]string{"provider", "method", "endpoint", "status_code"},
+			[]string{labelProvider, labelMethod, labelEndpoint, "status_code"},
 		),
 		HTTPRequestDuration: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -83,7 +90,7 @@ func New(version string) *Metrics {
 				Help:      "HTTP request duration in seconds",
 				Buckets:   prometheus.DefBuckets,
 			},
-			[]string{"provider", "method", "endpoint"},
+			[]string{labelProvider, labelMethod, labelEndpoint},
 		),
 		HTTPRequestsInFlight: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -91,7 +98,7 @@ func New(version string) *Metrics {
 				Name:      "http_requests_in_flight",
 				Help:      "Number of HTTP requests currently being processed",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		HTTPResponseSizeBytes: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -100,7 +107,7 @@ func New(version string) *Metrics {
 				Help:      "HTTP response size in bytes",
 				Buckets:   prometheus.ExponentialBuckets(100, 10, histogramBucketCount),
 			},
-			[]string{"provider", "method", "endpoint"},
+			[]string{labelProvider, labelMethod, labelEndpoint},
 		),
 		HTTPValidationErrorsTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -108,7 +115,7 @@ func New(version string) *Metrics {
 				Name:      "http_validation_errors_total",
 				Help:      "Total number of HTTP header validation errors",
 			},
-			[]string{"provider", "header_type"},
+			[]string{labelProvider, "header_type"},
 		),
 		HTTPJSONErrorsTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -116,7 +123,7 @@ func New(version string) *Metrics {
 				Name:      "http_json_errors_total",
 				Help:      "Total number of JSON decoding errors",
 			},
-			[]string{"provider", "endpoint"},
+			[]string{labelProvider, labelEndpoint},
 		),
 
 		// Business metrics
@@ -126,7 +133,7 @@ func New(version string) *Metrics {
 				Name:      "records",
 				Help:      "Current number of DNS records by type",
 			},
-			[]string{"provider", "record_type"},
+			[]string{labelProvider, labelRecordType},
 		),
 		ChangesTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -134,7 +141,7 @@ func New(version string) *Metrics {
 				Name:      "changes_total",
 				Help:      "Total number of DNS changes",
 			},
-			[]string{"provider", "operation"},
+			[]string{labelProvider, labelOperation},
 		),
 		ChangesByTypeTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -142,7 +149,7 @@ func New(version string) *Metrics {
 				Name:      "changes_by_type_total",
 				Help:      "Total number of DNS changes by record type",
 			},
-			[]string{"provider", "operation", "record_type"},
+			[]string{labelProvider, labelOperation, labelRecordType},
 		),
 		CNAMEConflictsTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -150,7 +157,7 @@ func New(version string) *Metrics {
 				Name:      "cname_conflicts_total",
 				Help:      "Total number of CNAME conflicts detected",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		IgnoredCNAMETargetsTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -158,7 +165,7 @@ func New(version string) *Metrics {
 				Name:      "ignored_cname_targets_total",
 				Help:      "Total number of ignored CNAME targets (only first target is used)",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		SRVParsingErrorsTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -166,7 +173,7 @@ func New(version string) *Metrics {
 				Name:      "srv_parsing_errors_total",
 				Help:      "Total number of SRV record parsing errors",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		BatchSize: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -175,7 +182,7 @@ func New(version string) *Metrics {
 				Help:      "Size of change batches",
 				Buckets:   prometheus.ExponentialBuckets(1, 2, 10),
 			},
-			[]string{"provider", "operation"},
+			[]string{labelProvider, labelOperation},
 		),
 
 		// Endpoint operations
@@ -185,7 +192,7 @@ func New(version string) *Metrics {
 				Name:      "adjust_endpoints_total",
 				Help:      "Total number of adjust endpoints calls",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		NegotiateTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -193,7 +200,7 @@ func New(version string) *Metrics {
 				Name:      "negotiate_total",
 				Help:      "Total number of negotiate calls",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 
 		// UniFi API metrics
@@ -203,7 +210,7 @@ func New(version string) *Metrics {
 				Name:      "unifi_api_errors_total",
 				Help:      "Total number of UniFi API errors",
 			},
-			[]string{"provider", "operation"},
+			[]string{labelProvider, labelOperation},
 		),
 		UniFiAPIDuration: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -212,7 +219,7 @@ func New(version string) *Metrics {
 				Help:      "UniFi API request duration in seconds",
 				Buckets:   prometheus.DefBuckets,
 			},
-			[]string{"provider", "operation"},
+			[]string{labelProvider, labelOperation},
 		),
 		UniFiLoginTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -220,7 +227,7 @@ func New(version string) *Metrics {
 				Name:      "unifi_login_total",
 				Help:      "Total number of UniFi login attempts",
 			},
-			[]string{"provider", "status"},
+			[]string{labelProvider, "status"},
 		),
 		UniFiReloginTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -228,7 +235,7 @@ func New(version string) *Metrics {
 				Name:      "unifi_relogin_total",
 				Help:      "Total number of UniFi re-login attempts after 401",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		UniFiCSRFRefreshesTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -236,7 +243,7 @@ func New(version string) *Metrics {
 				Name:      "unifi_csrf_refreshes_total",
 				Help:      "Total number of CSRF token refreshes",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		UniFiConnected: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -244,7 +251,7 @@ func New(version string) *Metrics {
 				Name:      "unifi_connected",
 				Help:      "UniFi connection status (1 = connected, 0 = disconnected)",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		UniFiResponseSizeBytes: promauto.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -253,7 +260,7 @@ func New(version string) *Metrics {
 				Help:      "UniFi API response size in bytes",
 				Buckets:   prometheus.ExponentialBuckets(100, 10, histogramBucketCount),
 			},
-			[]string{"operation"},
+			[]string{labelOperation},
 		),
 
 		// Quality metrics
@@ -263,7 +270,7 @@ func New(version string) *Metrics {
 				Name:      "consecutive_errors",
 				Help:      "Number of consecutive errors",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		LastSuccessTimestamp: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -271,7 +278,7 @@ func New(version string) *Metrics {
 				Name:      "last_success_timestamp",
 				Help:      "Timestamp of last successful operation",
 			},
-			[]string{"provider"},
+			[]string{labelProvider},
 		),
 		OperationSuccessRate: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -279,7 +286,7 @@ func New(version string) *Metrics {
 				Name:      "operation_success_rate",
 				Help:      "Success rate of operations (0-1)",
 			},
-			[]string{"operation"},
+			[]string{labelOperation},
 		),
 
 		// Info metric
@@ -289,7 +296,7 @@ func New(version string) *Metrics {
 				Name:      "info",
 				Help:      "Information about the webhook instance",
 			},
-			[]string{"version", "provider"},
+			[]string{"version", labelProvider},
 		),
 	}
 

--- a/pkg/webhook/mediatype_test.go
+++ b/pkg/webhook/mediatype_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Shared test fixtures, declared as constants to satisfy the goconst linter.
+const (
+	mtV1              = "application/external.dns.webhook+json;version=1"
+	mtV2              = "application/external.dns.webhook+json;version=2"
+	mtAppJSON         = "application/json"
+	mtV1Spaced        = " application/external.dns.webhook+json;version=1 "
+	mtV1Upper         = "Application/external.dns.webhook+json;version=1"
+	errMsgUnsupported = "unsupported media type version"
+)
+
 func TestMediaTypeVersion(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -16,12 +26,12 @@ func TestMediaTypeVersion(t *testing.T) {
 		{
 			name:     "version 1",
 			version:  "1",
-			expected: "application/external.dns.webhook+json;version=1",
+			expected: mtV1,
 		},
 		{
 			name:     "version 2",
 			version:  "2",
-			expected: "application/external.dns.webhook+json;version=2",
+			expected: mtV2,
 		},
 		{
 			name:     "empty version",
@@ -54,44 +64,44 @@ func TestMediaType_Is(t *testing.T) {
 	}{
 		{
 			name:        "exact match",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: "application/external.dns.webhook+json;version=1",
+			mediaType:   mtV1,
+			headerValue: mtV1,
 			expected:    true,
 		},
 		{
 			name:        "no match - different version",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: "application/external.dns.webhook+json;version=2",
+			mediaType:   mtV1,
+			headerValue: mtV2,
 			expected:    false,
 		},
 		{
 			name:        "no match - missing version",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: "application/external.dns.webhook+json;",
+			mediaType:   mtV1,
+			headerValue: mediaTypeFormat,
 			expected:    false,
 		},
 		{
 			name:        "no match - empty string",
-			mediaType:   "application/external.dns.webhook+json;version=1",
+			mediaType:   mtV1,
 			headerValue: "",
 			expected:    false,
 		},
 		{
 			name:        "no match - completely different",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: "application/json",
+			mediaType:   mtV1,
+			headerValue: mtAppJSON,
 			expected:    false,
 		},
 		{
 			name:        "no match - extra whitespace",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: " application/external.dns.webhook+json;version=1 ",
+			mediaType:   mtV1,
+			headerValue: mtV1Spaced,
 			expected:    false,
 		},
 		{
 			name:        "no match - case difference",
-			mediaType:   "application/external.dns.webhook+json;version=1",
-			headerValue: "Application/external.dns.webhook+json;version=1",
+			mediaType:   mtV1,
+			headerValue: mtV1Upper,
 			expected:    false,
 		},
 	}
@@ -116,100 +126,100 @@ func TestCheckAndGetMediaTypeHeaderValue(t *testing.T) {
 	}{
 		{
 			name:        "valid version 1",
-			value:       "application/external.dns.webhook+json;version=1",
+			value:       mtV1,
 			wantVersion: "1",
 			wantErr:     false,
 		},
 		{
 			name:        "unsupported version 2",
-			value:       "application/external.dns.webhook+json;version=2",
+			value:       mtV2,
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "unsupported version 0",
 			value:       "application/external.dns.webhook+json;version=0",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "missing version parameter",
-			value:       "application/external.dns.webhook+json;",
+			value:       mediaTypeFormat,
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "empty string",
 			value:       "",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "completely wrong media type",
-			value:       "application/json",
+			value:       mtAppJSON,
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "wrong format with version",
 			value:       "application/json;version=1",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "extra whitespace",
-			value:       " application/external.dns.webhook+json;version=1 ",
+			value:       mtV1Spaced,
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "case sensitive - uppercase",
-			value:       "Application/external.dns.webhook+json;version=1",
+			value:       mtV1Upper,
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "malformed - missing semicolon",
 			value:       "application/external.dns.webhook+jsonversion=1",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "malformed - extra parameters",
 			value:       "application/external.dns.webhook+json;version=1;charset=utf-8",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "version with leading zero",
 			value:       "application/external.dns.webhook+json;version=01",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "negative version",
 			value:       "application/external.dns.webhook+json;version=-1",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 		{
 			name:        "decimal version",
 			value:       "application/external.dns.webhook+json;version=1.0",
 			wantVersion: "",
 			wantErr:     true,
-			errContains: "unsupported media type version",
+			errContains: errMsgUnsupported,
 		},
 	}
 
@@ -244,7 +254,7 @@ func TestCheckAndGetMediaTypeHeaderValue(t *testing.T) {
 }
 
 func TestMediaTypeVersion1Constant(t *testing.T) {
-	expected := mediaType("application/external.dns.webhook+json;version=1")
+	expected := mediaType(mtV1)
 	if mediaTypeVersion1 != expected {
 		t.Errorf("mediaTypeVersion1 = %q, want %q", mediaTypeVersion1, expected)
 	}
@@ -255,7 +265,7 @@ func TestErrUnsupportedMediaType(t *testing.T) {
 		t.Error("errUnsupportedMediaType should not be nil")
 	}
 
-	expected := "unsupported media type version"
+	expected := errMsgUnsupported
 	if errUnsupportedMediaType.Error() != expected {
 		t.Errorf("errUnsupportedMediaType.Error() = %q, want %q", errUnsupportedMediaType.Error(), expected)
 	}
@@ -263,7 +273,7 @@ func TestErrUnsupportedMediaType(t *testing.T) {
 
 // TestCheckAndGetMediaTypeHeaderValueErrorMessage verifies error message format.
 func TestCheckAndGetMediaTypeHeaderValueErrorMessage(t *testing.T) {
-	value := "application/json"
+	value := mtAppJSON
 	_, err := checkAndGetMediaTypeHeaderValue(value)
 
 	if err == nil {
@@ -278,7 +288,7 @@ func TestCheckAndGetMediaTypeHeaderValueErrorMessage(t *testing.T) {
 	}
 
 	// Error should mention supported media types
-	if !strings.Contains(errMsg, "application/external.dns.webhook+json;version=1") {
+	if !strings.Contains(errMsg, mtV1) {
 		t.Errorf("error message should contain supported media type, got: %s", errMsg)
 	}
 


### PR DESCRIPTION

# Pull Request

## Summary

Extract repeated string literals into named constants to satisfy goconst (revealed by the latest golangci-lint via CI's pinned version: latest), and address the gosec findings:

- Add shared test constants in internal/unifi and pkg/webhook tests
- Reuse existing production constants where applicable
- Introduce Prometheus label-name constants in pkg/metrics
- Suppress G117 on the login credential marshal with an explanation

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvements
- [ ] Performance improvement

## Testing

<!-- Describe the tests you ran and/or how to verify the changes -->

- [x] Tested locally
- [ ] Unit tests pass
- [ ] Linters pass
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Related Issues

<!-- Link related issues here using "Closes #123" or "Fixes #123" -->

Closes #
