### PR TITLE
refactor: webhook/provider generics + unset API key from env after load

### DIFF
--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -118,7 +118,7 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	// before create at the plan level, so we keep the two phases ordered but
 	// parallelise within each phase.
 	deleteEPs := slices.Concat(changes.UpdateOld, changes.Delete)
-	if err := p.runBounded(ctx, deleteEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
+	if err := runBounded(ctx, p.workers, deleteEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
 		if err := p.deleteByIDs(ctx, byKeyType[ep.DNSName+ep.RecordType]); err != nil {
 			return fmt.Errorf("deleting endpoint %s (%s): %w", ep.DNSName, ep.RecordType, err)
 		}
@@ -130,7 +130,7 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	}
 
 	createEPs := slices.Concat(changes.Create, changes.UpdateNew)
-	if err := p.runBounded(ctx, createEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
+	if err := runBounded(ctx, p.workers, createEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
 		if ep.RecordType == recordTypeCNAME {
 			if ids := byKeyType[ep.DNSName+recordTypeCNAME]; len(ids) > 0 {
 				m.CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName).Inc()
@@ -177,23 +177,25 @@ func (p *UnifiProvider) deleteByIDs(ctx context.Context, ids []string) error {
 	return errors.Join(errs...)
 }
 
-// runBounded executes fn(ctx, ep) for every entry in eps with at most
-// p.workers in flight at any time. The first non-nil error cancels the
-// context and bubbles up; remaining workers see ctx.Err() and short-circuit.
-func (p *UnifiProvider) runBounded(
+// runBounded executes fn(ctx, item) for every entry in items with at most
+// limit in flight at any time. The first non-nil error cancels the context and
+// bubbles up; remaining workers see ctx.Err() and short-circuit. An empty slice
+// is a no-op.
+func runBounded[T any](
 	ctx context.Context,
-	eps []*endpoint.Endpoint,
-	fn func(context.Context, *endpoint.Endpoint) error,
+	limit int,
+	items []T,
+	fn func(context.Context, T) error,
 ) error {
-	if len(eps) == 0 {
+	if len(items) == 0 {
 		return nil
 	}
 
 	group, gctx := errgroup.WithContext(ctx)
-	group.SetLimit(p.workers)
+	group.SetLimit(limit)
 
-	for _, ep := range eps {
-		group.Go(func() error { return fn(gctx, ep) })
+	for _, item := range items {
+		group.Go(func() error { return fn(gctx, item) })
 	}
 
 	return group.Wait()

--- a/internal/unifi/types.go
+++ b/internal/unifi/types.go
@@ -12,7 +12,7 @@ import (
 // Config represents the configuration for the UniFi API.
 type Config struct {
 	Host              string        `env:"UNIFI_HOST,notEmpty"`
-	APIKey            string        `env:"UNIFI_API_KEY,notEmpty"`
+	APIKey            string        `env:"UNIFI_API_KEY,notEmpty,unset"`
 	Site              string        `env:"UNIFI_SITE"                envDefault:"default"`
 	ConsoleID         string        `env:"UNIFI_CONSOLE_ID"          envDefault:""`
 	SkipTLSVerify     bool          `env:"UNIFI_SKIP_TLS_VERIFY"     envDefault:"true"`

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -51,30 +51,17 @@ func (p *Webhook) Records(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
-	w.Header().Set(varyHeader, contentTypeHeader)
-	if err := json.NewEncoder(w).Encode(records); err != nil {
-		requestLog(r).Error("encoding records response", "error", err)
-	}
+	writeJSON(w, r, records, "records")
 }
 
 // ApplyChanges handles POST /records.
 func (p *Webhook) ApplyChanges(w http.ResponseWriter, r *http.Request) {
-	m := metrics.Get()
 	if err := p.checkContentType(w, r); err != nil {
 		return
 	}
 
-	var changes plan.Changes
-	if err := json.NewDecoder(r.Body).Decode(&changes); err != nil {
-		if isBodyTooLarge(err) {
-			writePlainError(w, r, http.StatusRequestEntityTooLarge, "request body too large")
-
-			return
-		}
-		m.HTTPJSONErrorsTotal.WithLabelValues(metrics.ProviderName, "/records").Inc()
-		writePlainError(w, r, http.StatusBadRequest, fmt.Sprintf("error decoding changes: %v", err))
-
+	changes, ok := decodeBody[plan.Changes](w, r, "/records")
+	if !ok {
 		return
 	}
 
@@ -97,8 +84,7 @@ func (p *Webhook) ApplyChanges(w http.ResponseWriter, r *http.Request) {
 
 // AdjustEndpoints handles POST /adjustendpoints.
 func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
-	m := metrics.Get()
-	m.AdjustEndpointsTotal.WithLabelValues(metrics.ProviderName).Inc()
+	metrics.Get().AdjustEndpointsTotal.WithLabelValues(metrics.ProviderName).Inc()
 
 	if err := p.checkContentType(w, r); err != nil {
 		return
@@ -107,16 +93,8 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var endpoints []*endpoint.Endpoint
-	if err := json.NewDecoder(r.Body).Decode(&endpoints); err != nil {
-		if isBodyTooLarge(err) {
-			writePlainError(w, r, http.StatusRequestEntityTooLarge, "request body too large")
-
-			return
-		}
-		m.HTTPJSONErrorsTotal.WithLabelValues(metrics.ProviderName, "/adjustendpoints").Inc()
-		writePlainError(w, r, http.StatusBadRequest, fmt.Sprintf("failed to decode request body: %v", err))
-
+	endpoints, ok := decodeBody[[]*endpoint.Endpoint](w, r, "/adjustendpoints")
+	if !ok {
 		return
 	}
 
@@ -128,11 +106,7 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
-	w.Header().Set(varyHeader, contentTypeHeader)
-	if err := json.NewEncoder(w).Encode(endpoints); err != nil {
-		requestLog(r).Error("encoding endpoints response", "error", err)
-	}
+	writeJSON(w, r, endpoints, "endpoints")
 }
 
 // Negotiate handles GET / and returns the provider's domain filter.
@@ -189,6 +163,40 @@ func validateMediaHeader(
 	}
 
 	return nil
+}
+
+// decodeBody decodes the JSON request body into T. On failure it writes the
+// appropriate error response — 413 when the configured body-size limit was
+// exceeded, 400 otherwise (counting the JSON error against route's endpoint
+// label) — and returns ok=false so the caller can simply return. It centralises
+// the decode handling shared by ApplyChanges and AdjustEndpoints.
+func decodeBody[T any](w http.ResponseWriter, r *http.Request, route string) (T, bool) {
+	var v T
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		if isBodyTooLarge(err) {
+			writePlainError(w, r, http.StatusRequestEntityTooLarge, "request body too large")
+
+			return v, false
+		}
+		metrics.Get().HTTPJSONErrorsTotal.WithLabelValues(metrics.ProviderName, route).Inc()
+		writePlainError(w, r, http.StatusBadRequest, fmt.Sprintf("error decoding request body: %v", err))
+
+		return v, false
+	}
+
+	return v, true
+}
+
+// writeJSON encodes v as the versioned-media-type response shared by the
+// Records and AdjustEndpoints handlers. A failed encode is logged but not
+// surfaced — the 200 status line is already on the wire by then. what labels
+// the log message ("records", "endpoints").
+func writeJSON(w http.ResponseWriter, r *http.Request, v any, what string) {
+	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
+	w.Header().Set(varyHeader, contentTypeHeader)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		requestLog(r).Error("encoding "+what+" response", "error", err)
+	}
 }
 
 // writePlainError writes a plaintext error response. A failed write is logged


### PR DESCRIPTION
A small **idiomatic-generics / DRY pass** on the webhook and provider layers, plus a one-tag secret-hygiene tweak.

Up front: this codebase is already model-grade idiomatic Go 1.26 — it already uses generics (`apiPage[T]`, `errors.AsType`, `new(value)`), method receivers throughout, the `provider.Provider` interface, and modern stdlib (`cmp.Or`, `slices.Concat`, `rand/v2`, bounded `errgroup`). So this is intentionally surgical rather than a rewrite — only the few places where a language feature genuinely removes duplication.

### Changes

- **`webhook.go` — generic `decodeBody[T]`**: `ApplyChanges` and `AdjustEndpoints` duplicated the same JSON request-body decode + error handling verbatim (413 when the body-size limit is exceeded, else 400 + the `http_json_errors_total` metric). Extracted into one generic helper returning `(T, ok)`, so each handler is now `x, ok := decodeBody[…](w, r, route); if !ok { return }`.
- **`webhook.go` — `writeJSON` helper**: `Records` and `AdjustEndpoints` repeated the identical versioned-media-type encode (`Content-Type` + `Vary` + `json.Encode` + log-on-error). Folded into one helper. (`Negotiate` is left alone — it deliberately omits `Vary` and writes 500 on encode error.)
- **`provider.go` — generic `runBounded[T]`**: `runBounded` was an endpoint-specific method; made it a generic free function (Go disallows type params on methods), i.e. a reusable bounded parallel-for. Call sites become `runBounded(ctx, p.workers, eps, fn)`.
- **`types.go` — `UNIFI_API_KEY,unset`**: add `caarlos0/env`'s `,unset` option so the key is removed from the process environment once loaded into the config struct — it's no longer exposed via `/proc/<pid>/environ`, inherited by any subprocess, or captured in an env dump. The value still lives in the config struct exactly as before (used per-request), so there's no behavioral change to the running service.

### Deliberately *not* done (avoiding over-engineering)

- Converting the `toDNSRecord`/`fromDNSRecord` type switches (6 fixed record types) to interface/registry dispatch — a `switch` is clearer here.
- Genericizing `client.go`'s `getJSON`/`decodeJSON`: since Go forbids generic methods, that would turn clean methods into free functions taking the receiver as a param — lateral churn for a tiny `var x; &x` saving. Happy to do it if you'd like it.
- New interfaces / generic metric registration — would be speculative abstraction.

### Notes

- **No behaviour change** beyond unifying the two 400 decode-error message strings into one (`error decoding request body: …`); no test asserts on the old wording. The `,unset` change affects only the process environment, not the loaded config.

### Verification

`go build` · `go vet` · `golangci-lint run` (0 issues) · `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
