### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -35,6 +39,13 @@ jobs:
         with:
           experimental: true
           install_args: --locked
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

Mirrors the CI-efficiency work from home-operations/kromgo#239, tailored to this repo's workflow files.

**Path filters (`paths-ignore: ["**.md"]`)** — skip CI runs for Markdown-only changes:
- `tests.yaml`, `lint.yaml`, `e2e.yaml` — added under both the `push:` and `pull_request:` triggers.
- `release.yaml` — added under the `push:` trigger only (deliberately *not* under `release:`, where the published-tag build must always run).

**Concurrency** — added where missing:
- `release.yaml` — groups by workflow + ref; cancels superseded `main` (rolling-tag) builds but never interrupts a published release (`cancel-in-progress: ${{ github.event_name != 'release' }}`).
- `release-please.yaml` — groups by workflow + ref with `cancel-in-progress: false` so release PR automation is never cancelled mid-run.
- `tests.yaml`, `lint.yaml`, `e2e.yaml` already had concurrency blocks — left untouched.

**golangci-lint cache** — `lint.yaml` runs `mise run lint` → `golangci-lint run`, so added a dedicated `actions/cache` step for `~/.cache/golangci-lint`, keyed on `go.sum` + `.golangci.yml`. This repo's lint job has no prior `actions/cache` step, so the cache step was placed immediately after "Setup Mise".

## Notes / skipped
- `release-please.yaml`, `renovate.yaml`, `stale.yaml` triggers left unchanged (per scope).
- No trigger in this repo uses a `paths:` allow-list, so no `paths-ignore` had to be skipped on that basis.
- This repo's `lint.yaml` is simpler than kromgo's (no embedded build assets, no pre-existing Go cache step), so the unrelated kromgo edits to the "Fetch build assets" step / comments do not apply here.

## Safety
Trigger-level path filters and concurrency only; no required status checks are touched and no job logic changes. zizmor `--offline` reports no new findings on all changed workflows.
