### PR TITLE
fix(server): run the readiness probe detached from the caller's request context

### DIFF
--- a/internal/server/readiness.go
+++ b/internal/server/readiness.go
@@ -12,6 +12,13 @@ import (
 // process should report ready. Returning a non-nil error fails the probe.
 type ProbeFunc func(ctx context.Context) error
 
+// probeTimeout bounds a single upstream readiness probe. The probe runs
+// detached from any caller's request context (see Check), so it needs its own
+// ceiling — without one a hung upstream connection (the UniFi client sets no
+// overall http.Client timeout, relying on ctx) would block the singleflight
+// slot forever. Generous enough to absorb the client's default retry budget.
+const probeTimeout = 10 * time.Second
+
 // cachedProbe wraps a ProbeFunc with a TTL-bounded result cache and
 // singleflight deduplication. Multiple concurrent /readyz hits within the
 // TTL share a single in-flight check; subsequent hits in that window return
@@ -52,7 +59,17 @@ func (c *cachedProbe) Check(ctx context.Context) error {
 			return nil, stillCached
 		}
 
-		err := c.probe(ctx)
+		// Detach from the caller's request context before probing. singleflight
+		// shares the leader's result with every queued caller, so if the leader's
+		// context is cancelled (a kubelet probe timeout, a dropped /readyz
+		// connection) the resulting context.Canceled would (a) fail all other
+		// in-flight callers whose own contexts are still alive and (b) get
+		// memoised as the readiness verdict for the whole TTL — knocking a healthy
+		// pod out of Service rotation. WithoutCancel keeps any context values but
+		// drops the cancellation; a fresh timeout still bounds the probe.
+		pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), probeTimeout)
+		err := c.probe(pctx)
+		cancel()
 
 		c.mu.Lock()
 		c.lastAt = time.Now()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -75,6 +75,38 @@ func TestCachedProbe_PropagatesError(t *testing.T) {
 	}
 }
 
+// TestCachedProbe_DetachesFromCallerContext verifies the probe runs detached
+// from the caller's request context: a caller whose context is already
+// cancelled (e.g. a kubelet probe that timed out, a dropped /readyz connection)
+// must not turn a healthy upstream into a cached "not ready" verdict for the
+// whole TTL. Regression test for the singleflight result/cache being poisoned
+// by one caller's cancellation.
+func TestCachedProbe_DetachesFromCallerContext(t *testing.T) {
+	var calls atomic.Int32
+	// Mirrors provider.Records honouring its context — it would return
+	// context.Canceled if handed an already-cancelled context.
+	probe := func(ctx context.Context) error {
+		calls.Add(1)
+
+		return ctx.Err()
+	}
+	cached := newCachedProbe(probe, time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the caller has already gone away before the probe runs
+
+	if err := cached.Check(ctx); err != nil {
+		t.Fatalf("Check with a cancelled caller context = %v; the probe should run detached and succeed", err)
+	}
+	// The good result — not the caller's cancellation — is what gets cached.
+	if err := cached.Check(context.Background()); err != nil {
+		t.Errorf("second Check = %v; a cancelled caller must not poison the cached verdict", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("probe ran %d times, want 1 (result cached)", got)
+	}
+}
+
 func TestReadyzHandler_ReturnsServiceUnavailableWhenProbeFails(t *testing.T) {
 	handler := readyzHandler(func(_ context.Context) error { return errors.New("nope") }, time.Minute)
 


### PR DESCRIPTION
## What

The cached `/readyz` probe runs under `singleflight`, and the leader caller's result is memoised for the full `ReadinessCacheTTL` (default 30s). The probe was run under the **caller's request context** (`c.probe(ctx)`), so a single client's cancellation — a kubelet probe `timeoutSeconds` expiry, a dropped `/readyz` connection — made `provider.Records` return `context.Canceled`. `singleflight` then:

1. handed that `context.Canceled` to **every other in-flight `/readyz` caller**, whose own contexts were still alive, and
2. **cached it as the readiness verdict** for the whole TTL,

knocking an otherwise-healthy pod out of Service rotation for up to 30s with no re-probe. With kubelet's short probe timeouts against a momentarily slow controller, the connection drop (and `r.Context()` cancellation) is routine.

Fixes #216.

## How

Run the probe under `context.WithTimeout(context.WithoutCancel(ctx), probeTimeout)` inside the singleflight closure:

- `context.WithoutCancel` keeps any context values but drops the caller's cancellation, so one client giving up can't fail the shared result or get cached as the verdict.
- The fresh `probeTimeout` (10s const) still bounds the probe — necessary because the UniFi `http.Client` sets no overall timeout and relies on context, so an un-timed detached context could block the singleflight slot forever on a hung upstream. A genuine timeout there is a legitimate "not ready" and is fine to cache.

No new config or API change.

## Test

`TestCachedProbe_DetachesFromCallerContext`: a probe that honours its context (returns `ctx.Err()`, mirroring `provider.Records`) is invoked via `Check` with an **already-cancelled** caller context; asserts `Check` returns `nil` (probe ran detached and succeeded), a second `Check` also returns `nil` (the good result, not the cancellation, was cached), and the probe ran exactly once. Fails pre-fix (returns `context.Canceled`).

`go test ./...` green; `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)