### PR TITLE
fix(unifi): don't retry non-idempotent POST creates on 5xx/network errors

### DIFF
--- a/internal/unifi/transport.go
+++ b/internal/unifi/transport.go
@@ -76,7 +76,7 @@ func (c *httpClient) doRequest(ctx context.Context, method, path string, body []
 			return resp, nil
 		}
 
-		retryable, wait := c.retryAfter(resp, err, attempt)
+		retryable, wait := c.retryAfter(method, resp, err, attempt)
 		if !retryable || attempt == attempts-1 {
 			if err != nil {
 				return nil, err
@@ -135,13 +135,24 @@ func (c *httpClient) doOnce(ctx context.Context, method, path string, body []byt
 	return resp, nil
 }
 
-// retryAfter returns whether a request should be retried and how long to
-// wait. 429 honours the server-supplied Retry-After header (clamped to
-// RetryMaxDelay); 5xx and network errors use exponential backoff with jitter.
-func (c *httpClient) retryAfter(resp *http.Response, err error, attempt int) (bool, time.Duration) {
-	// Network errors are retryable if they aren't context cancellations.
+// retryAfter returns whether a request should be retried and how long to wait.
+//
+// 429 is retried for any method — the server signals it rejected the request
+// before processing, so re-sending is safe. 5xx and network errors are retried
+// only for idempotent methods (GET/DELETE): a POST that creates a DNS record
+// may have been committed before the controller returned a 5xx or the
+// connection dropped, so blindly re-sending it could create a duplicate record.
+// A non-retried create still converges — external-dns retries the whole
+// reconcile on its next sync — without that duplication risk. 429 honours the
+// server-supplied Retry-After header (clamped to RetryMaxDelay); the rest use
+// exponential backoff with jitter.
+func (c *httpClient) retryAfter(method string, resp *http.Response, err error, attempt int) (bool, time.Duration) {
+	idempotent := method == http.MethodGet || method == http.MethodDelete
+
+	// Network errors are retryable if they aren't context cancellations — but
+	// only for idempotent methods (a POST may have landed before the break).
 	if err != nil {
-		if IsNetworkError(err) {
+		if IsNetworkError(err) && idempotent {
 			return true, c.backoff(attempt, 0)
 		}
 
@@ -157,7 +168,9 @@ func (c *httpClient) retryAfter(resp *http.Response, err error, attempt int) (bo
 		hint := parseRetryAfter(resp.Header.Get("Retry-After"))
 
 		return true, c.backoff(attempt, hint)
-	case resp.StatusCode >= 500 && resp.StatusCode < 600:
+	case resp.StatusCode >= 500 && resp.StatusCode < 600 && idempotent:
+		// A 5xx on a non-idempotent POST is ambiguous (the write may have
+		// committed), so don't auto-retry it.
 		return true, c.backoff(attempt, 0)
 	}
 

--- a/internal/unifi/transport_test.go
+++ b/internal/unifi/transport_test.go
@@ -88,6 +88,63 @@ func TestDoRequest_NoRetryOn4xx(t *testing.T) {
 	}
 }
 
+// TestDoRequest_PostNotRetriedOn5xx verifies a non-idempotent POST is NOT
+// retried on a 5xx. The controller may have committed the create before
+// returning the 5xx, so re-sending could duplicate the DNS record; external-dns
+// recovers via its own reconcile loop instead. (GET/DELETE still retry — see
+// TestDoRequest_RetriesOn5xxThenSucceeds.)
+func TestDoRequest_PostNotRetriedOn5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"message":"upstream"}`))
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(t, srv, nil)
+
+	_, err := c.doRequest(context.Background(), http.MethodPost, srv.URL+"/dns/policies", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected an error on 502")
+	}
+	if !isAPIError(err) {
+		t.Errorf("expected APIError, got %T: %v", err, err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("POST must not retry on 5xx: got %d attempts, want 1", got)
+	}
+}
+
+// TestDoRequest_PostRetriedOn429 verifies a POST IS still retried on 429: the
+// server rejected the request before processing, so re-sending is safe (and the
+// body is re-read each attempt).
+func TestDoRequest_PostRetriedOn429(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(t, srv, nil)
+
+	resp, err := c.doRequest(context.Background(), http.MethodPost, srv.URL+"/dns/policies", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("POST should retry on 429: got %d attempts, want 2", got)
+	}
+}
+
 func TestDoRequest_HonorsRetryAfterOn429(t *testing.T) {
 	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## What

`doRequest` applied one retry policy to every HTTP method — `retryAfter` returned retryable for any 5xx, 429, or network error with no method check, and the body is re-read from a fresh `bytes.NewReader` each attempt. `createOne` issues record creation via `POST /dns/policies`, which is **not idempotent** (the API represents multi-target endpoints as multiple identical records) and sends no idempotency key.

So if the controller returns a 5xx — or the connection drops — *after* committing the create, the retry re-POSTs and a **duplicate DNS record** is created. The next reconcile then groups both rows under the same Key+RecordType and external-dns sees a target it never planned.

Fixes #215.

> Severity note: this is PLAUSIBLE (duplication requires the UniFi API to return a retryable status after committing, or a post-send disconnect). The fix is the correct posture regardless — blind-retrying a non-idempotent write on an ambiguous failure is the anti-pattern; it doesn't depend on confirming UniFi's exact behavior.

## How

Gate the 5xx / network-error retry on the HTTP method (`retryAfter` now takes `method`):

- **GET / DELETE** (idempotent) — retry on 5xx, network errors, and 429, exactly as before.
- **POST** — retry **only** on `429` (the server signals it rejected the request before processing, so re-sending is safe). A 5xx or network error on a POST is ambiguous (the write may have landed), so it is **not** auto-retried.

A non-retried create still converges: external-dns retries the whole reconcile on its next sync, so correctness is preserved without the duplication risk. No config or API change.

## Test

- `TestDoRequest_PostNotRetriedOn5xx` — POST against an always-502 server makes exactly **1** attempt and returns an `APIError` (no retry).
- `TestDoRequest_PostRetriedOn429` — POST against a 429-then-200 server retries (2 attempts) and succeeds, confirming 429 is still safe to retry for POST.
- Existing GET retry tests (`TestDoRequest_RetriesOn5xxThenSucceeds`, `…NetworkErrorRetries`) still pass — idempotent retries are unchanged.

`go test ./...` green; `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)