### PR TITLE
fix(metrics): reset stale per-type records gauge after deletions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	golang.org/x/sync v0.21.0
 	sigs.k8s.io/external-dns v0.21.0
 )
@@ -44,7 +45,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect

--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -45,6 +45,16 @@ const (
 	recordTypeTXT   = "TXT"
 )
 
+// managedRecordTypes is every record type this provider emits (toDNSRecord
+// produces only these; all other policy types are skipped). Records() seeds its
+// per-type tally with all of them at zero so a type whose records were all
+// deleted is reported as 0 this cycle instead of leaving the gauge pinned at
+// its last value.
+var managedRecordTypes = []string{
+	recordTypeA, recordTypeAAAA, recordTypeCNAME,
+	recordTypeMX, recordTypeSRV, recordTypeTXT,
+}
+
 // pageLimit is the API's documented maximum page size.
 const pageLimit = 200
 

--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -59,8 +59,14 @@ func (p *UnifiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 	}
 
 	// Group supported records by key+type and tally per-type counts in one pass.
+	// Seed every managed type at zero so the per-type gauge is fully recomputed
+	// each cycle — a type whose records were all deleted is set to 0 rather than
+	// retaining its previous value.
 	groups := make(map[string][]DNSRecord)
-	counts := make(map[string]int)
+	counts := make(map[string]int, len(managedRecordTypes))
+	for _, rt := range managedRecordTypes {
+		counts[rt] = 0
+	}
 	for _, r := range records {
 		if !provider.SupportedRecordType(r.RecordType) {
 			continue

--- a/internal/unifi/provider_test.go
+++ b/internal/unifi/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/home-operations/external-dns-unifi-webhook/internal/metrics"
+	dto "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/external-dns/endpoint"
 	"sigs.k8s.io/external-dns/plan"
 )
@@ -123,5 +124,53 @@ func TestApplyChanges_CNAMEConflictUsesSnapshot(t *testing.T) {
 	}
 	if got := createCount.Load(); got != 1 {
 		t.Errorf("POST count = %d, want 1", got)
+	}
+}
+
+// TestRecords_ResetsStalePerTypeGauge verifies the per-type records gauge is
+// recomputed each call: once the last record of a type is deleted upstream, its
+// gauge must drop to 0 rather than retain the previous count. Regression for
+// the stale GaugeVec child (issue #218) — Records seeds every managed type at
+// zero so a vanished type is explicitly Set(0).
+func TestRecords_ResetsStalePerTypeGauge(t *testing.T) {
+	var page atomic.Pointer[dnsPolicyPage]
+	first := pageOf(
+		envA("id-1", "a.example.com", "192.0.2.1", 300),
+		envA("id-2", "b.example.com", "192.0.2.2", 300),
+	)
+	page.Store(&first)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(*page.Load())
+	}))
+	defer srv.Close()
+
+	p := &UnifiProvider{client: newTestClient(srv)}
+	gaugeA := metrics.Get().RecordsTotal.WithLabelValues(metrics.ProviderName, recordTypeA)
+	read := func() float64 {
+		t.Helper()
+		var m dto.Metric
+		if err := gaugeA.Write(&m); err != nil {
+			t.Fatalf("gauge.Write: %v", err)
+		}
+
+		return m.GetGauge().GetValue()
+	}
+
+	if _, err := p.Records(context.Background()); err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	if got := read(); got != 2 {
+		t.Fatalf("records{type=A} after first fetch = %v, want 2", got)
+	}
+
+	// All A records deleted upstream.
+	empty := pageOf()
+	page.Store(&empty)
+	if _, err := p.Records(context.Background()); err != nil {
+		t.Fatalf("Records (after deletion): %v", err)
+	}
+	if got := read(); got != 0 {
+		t.Errorf("records{type=A} after all A records deleted = %v, want 0 (stale gauge not reset)", got)
 	}
 }


### PR DESCRIPTION
## What

`Records()` tallied only the record types present in the current fetch into a fresh `counts` map and called `UpdateRecordsByType` (`RecordsTotal.WithLabelValues(...).Set(count)`) for **those types only** — there is no `Reset()`/`Delete()` on `RecordsTotal` anywhere. Once a type has been observed with N>0 and a later cycle returns zero records of that type, the type is absent from `counts`, `Set` is never called for it, and the `GaugeVec` child retains its last non-zero value indefinitely.

`Records()` runs on every `/records` reconcile **and** on the `/readyz` probe (every 30s), so the stale value is continuously re-exported: dashboards show phantom records and `externaldns_webhook_records{record_type="…"} == 0` alerts silently never fire.

Fixes #218.

## How

Seed the per-type tally with every **managed** record type (`A/AAAA/CNAME/MX/SRV/TXT` — the only types `toDNSRecord` emits) at zero before counting. The existing `for recordType, count := range counts { m.UpdateRecordsByType(...) }` loop then `Set`s **all** of them each cycle, so a type whose records were all deleted is explicitly `Set(0)` instead of left stale.

This avoids a `RecordsTotal.Reset()` (which would expose a transient all-zero window to a scrape landing mid-`Records`); the gauge is simply recomputed in full every call.

## Test

`TestRecords_ResetsStalePerTypeGauge`: fetch returns two A records → `records{type=A} == 2`; then the upstream returns zero records → `records{type=A} == 0` (fails pre-fix, where it stayed `2`). The gauge value is read via `client_model`'s `dto.Metric` (promoted from indirect to a direct dep — the repo had no metric-value assertions before; `go mod tidy` run).

`go test ./...` green; `golangci-lint run` 0 issues; `go mod tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)