### PR TITLE
fix(metrics): track consecutive_errors/last_success per operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	golang.org/x/sync v0.21.0
 	sigs.k8s.io/external-dns v0.21.0
 )
@@ -44,7 +45,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -315,11 +315,26 @@ func (m *Metrics) RecordUniFiAPICall(operation string, duration time.Duration, r
 	}
 	if err != nil {
 		m.UniFiAPIErrorsTotal.WithLabelValues(ProviderName, operation).Inc()
-		m.ConsecutiveErrors.WithLabelValues(ProviderName).Inc()
-	} else {
-		m.ConsecutiveErrors.WithLabelValues(ProviderName).Set(0)
-		m.LastSuccessTimestamp.WithLabelValues(ProviderName).Set(float64(time.Now().Unix()))
 	}
+}
+
+// RecordOperation records the outcome of one top-level provider operation (a
+// full Records or ApplyChanges). The consecutive-error and last-success gauges
+// are tracked here — per operation — rather than in RecordUniFiAPICall: a
+// single ApplyChanges fans out many concurrent UniFi API calls, and updating
+// these gauges from each of them races. One worker's success could Set the
+// count to 0 while its siblings are still failing, so "consecutive" lost all
+// meaning and an alert on consecutive_errors could silently never fire during a
+// failing batch. Per-operation accounting keeps it honest; per-call failures
+// are still counted unambiguously by UniFiAPIErrorsTotal.
+func (m *Metrics) RecordOperation(err error) {
+	if err != nil {
+		m.ConsecutiveErrors.WithLabelValues(ProviderName).Inc()
+
+		return
+	}
+	m.ConsecutiveErrors.WithLabelValues(ProviderName).Set(0)
+	m.LastSuccessTimestamp.WithLabelValues(ProviderName).Set(float64(time.Now().Unix()))
 }
 
 // UpdateRecordsByType updates the records count by type.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // newTestMetrics returns a Metrics instance backed by an isolated registry so
@@ -38,6 +39,47 @@ func TestRecordUniFiAPICall(t *testing.T) {
 
 	m.RecordUniFiAPICall("test_op", 50*time.Millisecond, 512, nil)
 	m.RecordUniFiAPICall("test_op", 50*time.Millisecond, 0, errors.New("boom"))
+}
+
+// gaugeValue reads the current value of a single gauge through the dto
+// round-trip. We deliberately avoid prometheus testutil here — it would drag a
+// test-only transitive dependency in just to read one float.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var metric dto.Metric
+	if err := g.Write(&metric); err != nil {
+		t.Fatalf("gauge.Write: %v", err)
+	}
+
+	return metric.GetGauge().GetValue()
+}
+
+func TestRecordOperation(t *testing.T) {
+	t.Parallel()
+	m := newTestMetrics(t)
+
+	consecutive := m.ConsecutiveErrors.WithLabelValues(ProviderName)
+	lastSuccess := m.LastSuccessTimestamp.WithLabelValues(ProviderName)
+
+	// Two failing operations accumulate the consecutive-error gauge and leave
+	// the last-success timestamp untouched.
+	m.RecordOperation(errors.New("boom"))
+	m.RecordOperation(errors.New("boom"))
+	if got := gaugeValue(t, consecutive); got != 2 {
+		t.Errorf("consecutive_errors after 2 failures = %v, want 2", got)
+	}
+	if got := gaugeValue(t, lastSuccess); got != 0 {
+		t.Errorf("last_success_timestamp should stay 0 while failing, got %v", got)
+	}
+
+	// A success resets the consecutive-error gauge and stamps last-success.
+	m.RecordOperation(nil)
+	if got := gaugeValue(t, consecutive); got != 0 {
+		t.Errorf("consecutive_errors after success = %v, want 0", got)
+	}
+	if got := gaugeValue(t, lastSuccess); got <= 0 {
+		t.Errorf("last_success_timestamp after success = %v, want > 0", got)
+	}
 }
 
 func TestUpdateRecordsByType(t *testing.T) {

--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -50,8 +50,9 @@ func NewUnifiProvider(config *Config) (provider.Provider, error) {
 }
 
 // Records returns the list of records in the DNS provider.
-func (p *UnifiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
+func (p *UnifiProvider) Records(ctx context.Context) (_ []*endpoint.Endpoint, err error) {
 	m := metrics.Get()
+	defer func() { m.RecordOperation(err) }()
 
 	records, err := p.client.GetEndpoints(ctx)
 	if err != nil {
@@ -98,8 +99,9 @@ func (p *UnifiProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, erro
 // produce 1+N paginated round trips per reconcile). DeleteRecord tolerates
 // 404 so the snapshot index is safe even if a record disappears between
 // snapshot and delete.
-func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
+func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes) (err error) {
 	m := metrics.Get()
+	defer func() { m.RecordOperation(err) }()
 
 	rawRecords, err := p.client.GetEndpoints(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

`consecutive_errors` and `last_success_timestamp` were being written from `RecordUniFiAPICall`, which fires **once per outbound UniFi HTTP call**. A single `ApplyChanges` fans those calls out across bounded worker pools (`runBounded`), so the two gauges were updated concurrently from many goroutines:

- one worker's success could `Set(0)` while its siblings were still failing (and vice versa), so the "consecutive" count no longer reflected anything coherent;
- an alert built on `consecutive_errors` could silently never fire during a sustained failing batch, because an interleaved success keeps zeroing it.

## Fix

Introduce `Metrics.RecordOperation(err error)` and call it **once per top-level provider operation** (`Records` / `ApplyChanges`) via a deferred named-return. The gauges now reflect whole-operation outcomes instead of racing per-call writes. Per-call failures remain counted unambiguously by `unifi_api_errors_total` (unchanged).

## Tests

- `TestRecordOperation` (new): two failures accumulate `consecutive_errors` to 2 and leave `last_success_timestamp` at 0; a subsequent success resets the count to 0 and stamps the timestamp. Reads gauges via the `dto` round-trip (no `testutil` dependency).
- Existing `Records` / `ApplyChanges` tests exercise the new deferred wiring.
- `go test ./...` green; `golangci-lint run` reports 0 issues.

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)