### PR TITLE
fix(unifi): cap the buffered JSON response read

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -52,6 +52,15 @@ const pageLimit = 200
 // hang the process forever.
 const siteResolveTimeout = 15 * time.Second
 
+// maxResponseBytes caps how much of a UniFi API response body we buffer into
+// memory before decoding. Integration API responses are small JSON documents
+// (a policy page is bounded by pageLimit), so a 25 MiB ceiling sits far above
+// any legitimate payload while still protecting the process from a buggy or
+// hostile controller streaming an unbounded body into io.ReadAll. It is a var
+// rather than a const so tests can lower it without generating multi-megabyte
+// fixtures.
+var maxResponseBytes int64 = 25 << 20 // 25 MiB
+
 var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // newUnifiClient constructs a UniFi API client and resolves the site name (or
@@ -133,9 +142,15 @@ func (c *httpClient) getJSON(ctx context.Context, reqURL, scope string, dest any
 // failures as DataErrors scoped by label. Returns the number of body bytes
 // read for metric accounting. The caller owns closing resp.Body.
 func decodeJSON(resp *http.Response, scope string, dest any) (int, error) {
-	body, err := io.ReadAll(resp.Body)
+	// Read one byte past the cap so a body sitting exactly at the limit still
+	// decodes while anything larger is rejected before we try to unmarshal it.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return 0, NewDataError("read", scope+" response body", err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return len(body), NewDataError("read", scope+" response body",
+			fmt.Errorf("response exceeds %d-byte limit", maxResponseBytes))
 	}
 	if err := json.Unmarshal(body, dest); err != nil {
 		return len(body), NewDataError("unmarshal", scope, err)

--- a/internal/unifi/client_test.go
+++ b/internal/unifi/client_test.go
@@ -3,6 +3,7 @@ package unifi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -646,5 +647,59 @@ func TestSetHeaders(t *testing.T) {
 		if got := req.Header.Get(key); got != want {
 			t.Errorf("Header %s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+// TestDecodeJSON_RejectsOversizedBody proves decodeJSON refuses to buffer a
+// response larger than maxResponseBytes instead of letting io.ReadAll grow
+// unbounded. These two tests are intentionally serial (no t.Parallel) because
+// they mutate the package-level cap; Go resumes parallel tests only after the
+// serial group finishes, so the deferred restore closes the window first.
+func TestDecodeJSON_RejectsOversizedBody(t *testing.T) {
+	defer func(orig int64) { maxResponseBytes = orig }(maxResponseBytes)
+	maxResponseBytes = 16
+
+	// Valid JSON, but well past the 16-byte cap. Decoding into a generic sink
+	// means the only thing that can fail here is the size guard — the old
+	// unbounded io.ReadAll would have buffered it all and returned nil.
+	oversized := `{"data":[` + strings.Repeat(`"x",`, 100) + `"x"]}`
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(oversized))}
+
+	var dest any
+	n, err := decodeJSON(resp, "DNS policies", &dest)
+	if err == nil {
+		t.Fatal("expected error for oversized body, got nil")
+	}
+
+	var dataErr *DataError
+	if !errors.As(err, &dataErr) {
+		t.Fatalf("expected *DataError, got %T: %v", err, err)
+	}
+	if !strings.Contains(dataErr.Error(), "limit") {
+		t.Errorf("error %q should mention the byte limit", dataErr.Error())
+	}
+	// Rejection must happen before unmarshalling, so dest stays nil.
+	if dest != nil {
+		t.Errorf("oversized body must not be decoded: got %v", dest)
+	}
+	// The over-limit read is reported (cap+1), never silently zeroed.
+	if int64(n) <= maxResponseBytes {
+		t.Errorf("byte count = %d, want > cap %d", n, maxResponseBytes)
+	}
+}
+
+// TestDecodeJSON_AcceptsBodyAtLimit guards the boundary: a body sitting exactly
+// at maxResponseBytes still decodes (the +1 LimitReader headroom is what lets
+// it through), so a tight-but-legitimate payload is never rejected.
+func TestDecodeJSON_AcceptsBodyAtLimit(t *testing.T) {
+	defer func(orig int64) { maxResponseBytes = orig }(maxResponseBytes)
+
+	body := `{}`
+	maxResponseBytes = int64(len(body)) // exactly at the cap
+
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+	var dest dnsPolicyPage
+	if _, err := decodeJSON(resp, "DNS policies", &dest); err != nil {
+		t.Fatalf("body exactly at the limit should decode, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`decodeJSON` buffered the entire UniFi API response body via `io.ReadAll(resp.Body)` with **no upper bound**. A buggy or hostile controller streaming a very large (or endless) body would be read straight into memory, so a single malformed response could exhaust the process and take the webhook down. This is on every read path (`GetEndpoints` pagination, `createOne`, `resolveSite`).

## Fix

Wrap the read in `io.LimitReader(resp.Body, maxResponseBytes+1)` and reject anything over the cap with a `DataError` **before** unmarshalling. The `+1` headroom lets a body sitting exactly at the limit through while rejecting anything larger.

- `maxResponseBytes = 25 MiB` — orders of magnitude above any legitimate Integration API page (bounded by `pageLimit = 200`).
- It's a package `var` rather than a `const` so tests can lower it without synthesising multi-megabyte fixtures.

## Tests

- `TestDecodeJSON_RejectsOversizedBody` (new): with the cap lowered, an oversized but otherwise-valid body decoded into a generic sink is rejected with a `DataError` mentioning the limit, is **not** unmarshalled, and reports the over-limit byte count. (The old unbounded code would have returned `nil`.)
- `TestDecodeJSON_AcceptsBodyAtLimit` (new): a body sitting exactly at the cap still decodes — guards the `+1` boundary.
- Both are intentionally serial (they mutate the package-level cap); Go resumes parallel tests only after the serial group finishes, so the deferred restore closes the window first.
- `go test ./...` green; `golangci-lint run` reports 0 issues.

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)