### PR TITLE
fix(unifi): key record groups by a struct, not concatenated name+type

### DIFF
--- a/internal/unifi/client_test.go
+++ b/internal/unifi/client_test.go
@@ -93,6 +93,13 @@ func envA(id, domain, ip string, ttl int) dnsPolicyEnvelope {
 	}
 }
 
+func envAAAA(id, domain, ip string, ttl int) dnsPolicyEnvelope {
+	return dnsPolicyEnvelope{
+		ID: id, Type: policyTypeAAAA, Enabled: true,
+		Domain: domain, IPv6Address: ip, TTLSeconds: &ttl,
+	}
+}
+
 func envCNAME(id, domain, target string, ttl int) dnsPolicyEnvelope {
 	return dnsPolicyEnvelope{
 		ID: id, Type: policyTypeCNAME, Enabled: true,

--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -16,6 +16,19 @@ import (
 
 const defaultApplyWorkers = 5
 
+// recordKey identifies a record set by its DNS name and type. It is used as a
+// map key in place of string concatenation: concatenating r.Key+r.RecordType
+// is ambiguous because the type strings are not self-delimiting, so an A record
+// for the name "x.AAA" and an AAAA record for the name "x." both flatten to the
+// same "x.AAAA" string. That collision would group two unrelated records
+// together and, on the delete path, resolve one endpoint to the other's record
+// IDs — silently deleting a bystander. A struct key compares field-wise and
+// cannot collide.
+type recordKey struct {
+	name       string
+	recordType string
+}
+
 // UnifiProvider type for interfacing with UniFi.
 //
 //nolint:revive // UnifiProvider is the correct name for this provider, renaming would be a breaking change
@@ -63,7 +76,7 @@ func (p *UnifiProvider) Records(ctx context.Context) (_ []*endpoint.Endpoint, er
 	// Seed every managed type at zero so the per-type gauge is fully recomputed
 	// each cycle — a type whose records were all deleted is set to 0 rather than
 	// retaining its previous value.
-	groups := make(map[string][]DNSRecord)
+	groups := make(map[recordKey][]DNSRecord)
 	counts := make(map[string]int, len(managedRecordTypes))
 	for _, rt := range managedRecordTypes {
 		counts[rt] = 0
@@ -72,7 +85,8 @@ func (p *UnifiProvider) Records(ctx context.Context) (_ []*endpoint.Endpoint, er
 		if !provider.SupportedRecordType(r.RecordType) {
 			continue
 		}
-		groups[r.Key+r.RecordType] = append(groups[r.Key+r.RecordType], r)
+		key := recordKey{r.Key, r.RecordType}
+		groups[key] = append(groups[key], r)
 		counts[r.RecordType]++
 	}
 
@@ -99,7 +113,7 @@ func (p *UnifiProvider) Records(ctx context.Context) (_ []*endpoint.Endpoint, er
 
 // ApplyChanges applies a given set of changes in the DNS provider.
 //
-// The full record set is fetched once at the top and indexed by Key+RecordType
+// The full record set is fetched once at the top and indexed by name+type
 // so per-endpoint deletes and CNAME-conflict cleanup can resolve target
 // record IDs locally instead of re-fetching the list per call (which used to
 // produce 1+N paginated round trips per reconcile). DeleteRecord tolerates
@@ -127,7 +141,7 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	// parallelise within each phase.
 	deleteEPs := slices.Concat(changes.UpdateOld, changes.Delete)
 	if err := runBounded(ctx, p.workers, deleteEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
-		if err := p.deleteByIDs(ctx, byKeyType[ep.DNSName+ep.RecordType]); err != nil {
+		if err := p.deleteByIDs(ctx, byKeyType[recordKey{ep.DNSName, ep.RecordType}]); err != nil {
 			return fmt.Errorf("deleting endpoint %s (%s): %w", ep.DNSName, ep.RecordType, err)
 		}
 		m.RecordChange("delete", ep.RecordType)
@@ -140,7 +154,7 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	createEPs := slices.Concat(changes.Create, changes.UpdateNew)
 	if err := runBounded(ctx, p.workers, createEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
 		if ep.RecordType == recordTypeCNAME {
-			if ids := byKeyType[ep.DNSName+recordTypeCNAME]; len(ids) > 0 {
+			if ids := byKeyType[recordKey{ep.DNSName, recordTypeCNAME}]; len(ids) > 0 {
 				m.CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName).Inc()
 				if err := p.deleteByIDs(ctx, ids); err != nil {
 					return fmt.Errorf("deleting conflicting CNAME %s: %w", ep.DNSName, err)
@@ -160,12 +174,12 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 	return nil
 }
 
-// indexRecordIDs groups record IDs by Key+RecordType so the delete path can
+// indexRecordIDs groups record IDs by name+type so the delete path can
 // resolve "all IDs for endpoint X" in O(1) without re-listing.
-func indexRecordIDs(records []DNSRecord) map[string][]string {
-	out := make(map[string][]string, len(records))
+func indexRecordIDs(records []DNSRecord) map[recordKey][]string {
+	out := make(map[recordKey][]string, len(records))
 	for _, r := range records {
-		key := r.Key + r.RecordType
+		key := recordKey{r.Key, r.RecordType}
 		out[key] = append(out[key], r.ID)
 	}
 

--- a/internal/unifi/provider_test.go
+++ b/internal/unifi/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -172,5 +173,82 @@ func TestRecords_ResetsStalePerTypeGauge(t *testing.T) {
 	}
 	if got := read(); got != 0 {
 		t.Errorf("records{type=A} after all A records deleted = %v, want 0 (stale gauge not reset)", got)
+	}
+}
+
+// TestRecords_DistinguishesCollidingKeys is the grouping half of the #222
+// regression. Before the recordKey struct fix, records were grouped by the
+// bare string r.Key+r.RecordType, which is ambiguous: an A record for
+// "host.example.comAAA" and an AAAA record for "host.example.com" both flatten
+// to "host.example.comAAAA" and were merged into a single endpoint (the second
+// type silently dropped). They must come back as two distinct endpoints.
+func TestRecords_DistinguishesCollidingKeys(t *testing.T) {
+	existing := pageOf(
+		envA("id-a", "host.example.comAAA", "192.0.2.1", 300),
+		envAAAA("id-aaaa", "host.example.com", "2001:db8::1", 300),
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(existing)
+	}))
+	defer srv.Close()
+
+	p := &UnifiProvider{client: newTestClient(srv)}
+	eps, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+
+	// Classify by type/target rather than DNSName so the assertion does not
+	// depend on external-dns name normalisation.
+	var aOK, aaaaOK bool
+	for _, ep := range eps {
+		switch ep.RecordType {
+		case recordTypeA:
+			aOK = len(ep.Targets) == 1 && ep.Targets[0] == "192.0.2.1"
+		case recordTypeAAAA:
+			aaaaOK = len(ep.Targets) == 1 && ep.Targets[0] == "2001:db8::1"
+		}
+	}
+	if len(eps) != 2 || !aOK || !aaaaOK {
+		t.Fatalf("want 2 endpoints (A→192.0.2.1, AAAA→2001:db8::1); got %d merged by key collision: %+v", len(eps), eps)
+	}
+}
+
+// TestApplyChanges_DeleteDoesNotCollideAcrossTypes is the data-loss half of
+// the #222 regression: deleting one endpoint must not take out an unrelated
+// record that shared the old concatenated key. "host.example.comAAA"/A and
+// "host.example.com"/AAAA both concatenated to "host.example.comAAAA", so
+// deleting the A record used to delete the AAAA record's ID as collateral.
+func TestApplyChanges_DeleteDoesNotCollideAcrossTypes(t *testing.T) {
+	existing := []dnsPolicyEnvelope{
+		envA("id-a", "host.example.comAAA", "192.0.2.1", 300),
+		envAAAA("id-aaaa", "host.example.com", "2001:db8::1", 300),
+	}
+
+	var deleted sync.Map
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(pageOf(existing...))
+		case http.MethodDelete:
+			deleted.Store(path.Base(r.URL.Path), struct{}{})
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	p := &UnifiProvider{client: newTestClient(srv), workers: 1}
+	changes := &plan.Changes{
+		Delete: []*endpoint.Endpoint{endpoint.NewEndpoint("host.example.comAAA", "A", "192.0.2.1")},
+	}
+	if err := p.ApplyChanges(context.Background(), changes); err != nil {
+		t.Fatalf("ApplyChanges: %v", err)
+	}
+
+	if _, hit := deleted.Load("id-a"); !hit {
+		t.Error("expected the targeted A record id-a to be deleted")
+	}
+	if _, hit := deleted.Load("id-aaaa"); hit {
+		t.Error("AAAA record id-aaaa was deleted as collateral — Key+RecordType collision (#222)")
 	}
 }


### PR DESCRIPTION
## Summary

Record grouping in `Records` and the snapshot index in `ApplyChanges` built their map keys by concatenating `r.Key + r.RecordType`. The record-type strings are **not self-delimiting**, so the concatenation is ambiguous:

- an A record for the name `host.example.comAAA` → `host.example.comAAAA`
- an AAAA record for the name `host.example.com` → `host.example.comAAAA`

Both collapse to the same string key. The consequences:

- **`Records`**: the two records are grouped together and emitted as a *single* endpoint — the second type is silently dropped.
- **`ApplyChanges` delete path**: deleting one endpoint resolves to the *other* record's IDs via the shared key, **silently deleting a bystander record** (data loss).

## Fix

Replace all four concatenation sites (grouping, index build, delete lookup, CNAME-conflict lookup) with a `recordKey{name, recordType}` struct key. Struct keys compare field-wise and cannot collide.

## Tests

- `TestRecords_DistinguishesCollidingKeys` — the colliding A/AAAA pair must come back as two distinct endpoints.
- `TestApplyChanges_DeleteDoesNotCollideAcrossTypes` — deleting the A record must delete only its own ID, not the AAAA record's.
- Both were confirmed to **fail against the pre-fix code** (the A/AAAA records merge into one endpoint with both targets, and the AAAA record is deleted as collateral) and pass after.
- `go test ./...` green; `golangci-lint run` reports 0 issues.

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)