### PR TITLE
fix(unifi): size the startup site-resolution timeout to the retry budget

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -58,9 +58,22 @@ var managedRecordTypes = []string{
 // pageLimit is the API's documented maximum page size.
 const pageLimit = 200
 
-// siteResolveTimeout caps the startup probe so a broken controller doesn't
-// hang the process forever.
-const siteResolveTimeout = 15 * time.Second
+// siteResolveBaseTimeout is the headroom the startup site-resolution probe
+// gets for the HTTP request(s) themselves. The effective timeout adds the
+// worst-case retry backoff budget on top (see siteResolveTimeoutFor), so a
+// broken controller still can't hang the process forever, but raising the
+// retry knobs never starves the probe mid-backoff.
+const siteResolveBaseTimeout = 15 * time.Second
+
+// siteResolveTimeoutFor returns how long the startup probe may run for the
+// given config: the fixed request headroom plus the worst-case time the retry
+// loop can spend in backoff. Deriving it from the retry settings (rather than a
+// fixed cap) is what stops an operator who raises UNIFI_RETRY_ATTEMPTS — to ride
+// out a slow or rate-limiting controller — from instead tripping a startup
+// context deadline and crashlooping on every restart.
+func siteResolveTimeoutFor(cfg *Config) time.Duration {
+	return siteResolveBaseTimeout + worstCaseRetryBudget(cfg)
+}
 
 // maxResponseBytes caps how much of a UniFi API response body we buffer into
 // memory before decoding. Integration API responses are small JSON documents
@@ -91,7 +104,7 @@ func newUnifiClient(config *Config) (*httpClient, error) {
 		httpc: extdnshttp.NewInstrumentedClient(&http.Client{Transport: transport}),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), siteResolveTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), siteResolveTimeoutFor(config))
 	defer cancel()
 	siteID, err := c.resolveSite(ctx, config.Site)
 	if err != nil {

--- a/internal/unifi/transport.go
+++ b/internal/unifi/transport.go
@@ -213,6 +213,24 @@ func (c *httpClient) backoff(attempt int, hint time.Duration) time.Duration {
 	return wait
 }
 
+// worstCaseRetryBudget returns an upper bound on the total time doRequest can
+// spend sleeping between attempts for the given config. doRequest sleeps once
+// after each attempt except the last, so there are at most RetryAttempts-1
+// waits. Every individual wait is capped at RetryMaxDelay by backoff(), and any
+// wait can be driven all the way up to that cap by a server Retry-After hint on
+// a 429 (backoff honours the hint as a floor, then clamps to RetryMaxDelay). So
+// the tight, hint-safe upper bound is simply (RetryAttempts-1) * RetryMaxDelay —
+// the exponential schedule only ever produces shorter waits, never longer. Used
+// to size the startup site-resolution timeout: a fixed cap that ignores this
+// budget would cancel retries the operator explicitly asked for and crashloop
+// the process.
+func worstCaseRetryBudget(cfg *Config) time.Duration {
+	attempts := max(cfg.RetryAttempts, 1)
+	maxDelay := cmp.Or(cfg.RetryMaxDelay, 10*time.Second)
+
+	return time.Duration(attempts-1) * maxDelay
+}
+
 // parseRetryAfter understands both numeric-seconds and HTTP-date forms of
 // the Retry-After header. Unparseable values produce zero, which lets the
 // caller fall through to ordinary backoff.

--- a/internal/unifi/transport_test.go
+++ b/internal/unifi/transport_test.go
@@ -236,6 +236,77 @@ func TestBackoff_ClampsToMax(t *testing.T) {
 	}
 }
 
+func TestWorstCaseRetryBudget(t *testing.T) {
+	// The bound is (attempts-1) * RetryMaxDelay: each of the attempts-1 waits
+	// can be driven to RetryMaxDelay by a 429 Retry-After hint, so the initial
+	// delay does not enter into the worst case.
+	tests := []struct {
+		name string
+		cfg  *Config
+		want time.Duration
+	}{
+		{
+			name: "single attempt has no backoff waits",
+			cfg:  &Config{RetryAttempts: 1, RetryInitialDelay: 500 * time.Millisecond, RetryMaxDelay: 10 * time.Second},
+			want: 0,
+		},
+		{
+			name: "three attempts: two waits at the ceiling",
+			cfg:  &Config{RetryAttempts: 3, RetryInitialDelay: 500 * time.Millisecond, RetryMaxDelay: 10 * time.Second},
+			want: 20 * time.Second,
+		},
+		{
+			name: "six attempts: five waits at the ceiling",
+			cfg:  &Config{RetryAttempts: 6, RetryInitialDelay: 500 * time.Millisecond, RetryMaxDelay: 10 * time.Second},
+			want: 50 * time.Second,
+		},
+		{
+			name: "a tiny initial delay does not shrink the bound",
+			cfg:  &Config{RetryAttempts: 3, RetryInitialDelay: 1 * time.Millisecond, RetryMaxDelay: 10 * time.Second},
+			want: 20 * time.Second,
+		},
+		{
+			name: "zero RetryMaxDelay falls back to the 10s default",
+			cfg:  &Config{RetryAttempts: 3},
+			want: 20 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := worstCaseRetryBudget(tt.cfg); got != tt.want {
+				t.Errorf("worstCaseRetryBudget = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSiteResolveTimeoutFor_CoversRetryBudget is the #223 regression: the
+// startup probe timeout must scale with the operator's retry settings instead
+// of being a fixed cap that cancels configured retries mid-backoff.
+func TestSiteResolveTimeoutFor_CoversRetryBudget(t *testing.T) {
+	// A retry budget the old fixed 15s site-resolution cap would have truncated.
+	cfg := &Config{RetryAttempts: 6, RetryInitialDelay: 500 * time.Millisecond, RetryMaxDelay: 10 * time.Second}
+
+	budget := worstCaseRetryBudget(cfg)
+	if budget <= siteResolveBaseTimeout {
+		t.Fatalf("test premise broken: budget %v should exceed the %v base headroom", budget, siteResolveBaseTimeout)
+	}
+
+	got := siteResolveTimeoutFor(cfg)
+	if want := siteResolveBaseTimeout + budget; got != want {
+		t.Errorf("siteResolveTimeoutFor = %v, want base %v + budget %v = %v", got, siteResolveBaseTimeout, budget, want)
+	}
+	if got <= budget {
+		t.Errorf("startup timeout %v must leave request headroom beyond the retry budget %v", got, budget)
+	}
+
+	// With retries disabled the timeout collapses to just the base headroom.
+	none := &Config{RetryAttempts: 1, RetryInitialDelay: 500 * time.Millisecond, RetryMaxDelay: 10 * time.Second}
+	if got := siteResolveTimeoutFor(none); got != siteResolveBaseTimeout {
+		t.Errorf("no-retry timeout = %v, want base %v", got, siteResolveBaseTimeout)
+	}
+}
+
 func TestNewHTTPTransport_SkipTLSVerify(t *testing.T) {
 	tr, err := newHTTPTransport(&Config{SkipTLSVerify: true})
 	if err != nil {


### PR DESCRIPTION
## Summary

The startup site-resolution probe (`newUnifiClient` → `resolveSite`) was wrapped in a **fixed 15s** context timeout. That probe's request flows through the same exponential-backoff retry loop the rest of the client uses, whose budget is operator-tunable via `UNIFI_RETRY_ATTEMPTS` / `UNIFI_RETRY_INITIAL_DELAY` / `UNIFI_RETRY_MAX_DELAY` (attempts may be raised up to 10).

An operator who raises the attempt count — precisely to ride out a slow or rate-limiting controller — pushes the worst-case backoff past 15s. The context is then cancelled mid-backoff, `NewUnifiProvider` returns an opaque `context deadline exceeded`, and the process **crashloops on every restart**.

## Fix

Derive the probe timeout from the config:

```
siteResolveTimeoutFor(cfg) = siteResolveBaseTimeout (15s request headroom) + worstCaseRetryBudget(cfg)
```

Because a `429` `Retry-After` hint can drive **any** single wait all the way up to `RetryMaxDelay` (backoff honours the hint as a floor, then clamps to `RetryMaxDelay`), the tight, hint-safe upper bound on total sleep is `(RetryAttempts-1) * RetryMaxDelay` — the exponential schedule only ever produces *shorter* waits. The probe still can't hang forever (the budget is finite), but it can no longer starve retries the operator explicitly configured.

> The `(attempts-1) * maxDelay` bound (rather than summing the exponential schedule) came out of an adversarial self-review: a `429` + `Retry-After` storm at startup can hold each wait at the ceiling, which a backoff-only sum would under-count.

## Tests

- `TestWorstCaseRetryBudget` — pins the `(attempts-1) * RetryMaxDelay` bound across attempt counts, a tiny initial delay, and the zero-value default.
- `TestSiteResolveTimeoutFor_CoversRetryBudget` — the startup timeout equals base + budget, always covers the retry budget, and collapses to just the base when retries are disabled.
- `go test ./...` green; `golangci-lint run` reports 0 issues.

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)