### PR TITLE
fix(unifi): skip disabled UniFi policies instead of reporting them as live

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -245,7 +245,6 @@ func (c *httpClient) CreateEndpoint(ctx context.Context, endpoint *externaldnsen
 	created = make([]*DNSRecord, 0, len(endpoint.Targets))
 	for _, target := range endpoint.Targets {
 		r := DNSRecord{
-			Enabled:    true,
 			Key:        endpoint.DNSName,
 			RecordType: endpoint.RecordType,
 			TTL:        endpoint.RecordTTL,

--- a/internal/unifi/dto.go
+++ b/internal/unifi/dto.go
@@ -81,13 +81,23 @@ type siteEntry struct {
 }
 
 // toDNSRecord converts a wire envelope into the internal DNSRecord shape.
-// ok=false means the envelope should be skipped (FORWARD_DOMAIN entries or
-// unknown discriminator values — we don't pretend to manage them).
+// ok=false means the envelope should be skipped: a disabled policy (not serving
+// DNS), a FORWARD_DOMAIN entry, or an unknown discriminator value — none of
+// which we pretend to manage.
+//
+// Disabled policies are skipped rather than reported because external-dns has
+// no "disabled" concept; surfacing one would make external-dns believe a parked
+// record is live. Treating it as not-present lets external-dns re-create the
+// record (enabled) if it is still in the desired set, and otherwise leave it
+// alone. See #221.
 func toDNSRecord(env dnsPolicyEnvelope) (DNSRecord, bool) {
+	if !env.Enabled {
+		return DNSRecord{}, false
+	}
+
 	r := DNSRecord{
-		ID:      env.ID,
-		Enabled: env.Enabled,
-		Key:     env.Domain,
+		ID:  env.ID,
+		Key: env.Domain,
 	}
 	if env.TTLSeconds != nil {
 		r.TTL = endpoint.TTL(*env.TTLSeconds)
@@ -126,6 +136,8 @@ func toDNSRecord(env dnsPolicyEnvelope) (DNSRecord, bool) {
 // POST /dns/policies. TTL is clamped per-type to the spec's documented maxima.
 func fromDNSRecord(r DNSRecord) (dnsPolicyEnvelope, error) {
 	env := dnsPolicyEnvelope{
+		// Records external-dns asks us to write are always live; "disabled" is
+		// a manual UI state we deliberately don't model (see toDNSRecord, #221).
 		Enabled: true,
 		Domain:  r.Key,
 	}

--- a/internal/unifi/dto_test.go
+++ b/internal/unifi/dto_test.go
@@ -85,7 +85,18 @@ func TestToDNSRecord_PerType(t *testing.T) {
 		},
 		{
 			name:   "unknown type is dropped",
-			env:    dnsPolicyEnvelope{Type: "MYSTERY", Domain: "x"},
+			env:    dnsPolicyEnvelope{Type: "MYSTERY", Enabled: true, Domain: "x"},
+			wantOK: false,
+		},
+		{
+			// A fully valid A record, but disabled in the UI: must not be
+			// surfaced as a managed record (#221).
+			name: "disabled record is dropped",
+			env: dnsPolicyEnvelope{
+				Type: policyTypeA, Enabled: false,
+				Domain: "parked.example.com", IPv4Address: "192.0.2.9",
+				TTLSeconds: new(300),
+			},
 			wantOK: false,
 		},
 	}

--- a/internal/unifi/provider_test.go
+++ b/internal/unifi/provider_test.go
@@ -252,3 +252,32 @@ func TestApplyChanges_DeleteDoesNotCollideAcrossTypes(t *testing.T) {
 		t.Error("AAAA record id-aaaa was deleted as collateral — Key+RecordType collision (#222)")
 	}
 }
+
+// TestRecords_ExcludesDisabledRecords proves a policy disabled in the UniFi UI
+// is not reported as a managed endpoint (#221): external-dns must not believe a
+// parked record is live.
+func TestRecords_ExcludesDisabledRecords(t *testing.T) {
+	disabled := envA("id-off", "off.example.com", "192.0.2.8", 300)
+	disabled.Enabled = false
+	existing := pageOf(
+		envA("id-on", "on.example.com", "192.0.2.1", 300),
+		disabled,
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(existing)
+	}))
+	defer srv.Close()
+
+	p := &UnifiProvider{client: newTestClient(srv)}
+	eps, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+
+	if len(eps) != 1 {
+		t.Fatalf("got %d endpoints, want 1 (the disabled record must be excluded): %+v", len(eps), eps)
+	}
+	if eps[0].DNSName != "on.example.com" {
+		t.Errorf("endpoint = %q, want on.example.com (the enabled record)", eps[0].DNSName)
+	}
+}

--- a/internal/unifi/types.go
+++ b/internal/unifi/types.go
@@ -100,7 +100,6 @@ func (c Config) Validate() error {
 // For all other types, Value is the raw target.
 type DNSRecord struct {
 	ID         string
-	Enabled    bool
 	Key        string
 	RecordType string
 	TTL        endpoint.TTL


### PR DESCRIPTION
## Summary

`toDNSRecord` copied `env.Enabled` into `DNSRecord.Enabled`, but **nothing ever read it**: `GetEndpoints`/`Records` reported every converted record, and the write path hardcoded `Enabled: true`. So a policy an operator disabled in the UniFi UI (to park a record without deleting it) was still surfaced to external-dns as a *live* endpoint — external-dns has no "disabled" concept, so it believed a parked record was serving (silent divergence), and any write that touched the record forced it back on.

## Fix

Treat a disabled policy as **not-present**: `toDNSRecord` now returns `ok=false` when `env.Enabled` is false, alongside the existing `FORWARD_DOMAIN` / unknown-type skips. external-dns then re-creates the record (enabled) if it is still in the desired set, and otherwise leaves it alone — the policy the issue recommended.

- The `DNSRecord.Enabled` field was dead (written in two places, read nowhere), so it's removed.
- `fromDNSRecord` keeps `Enabled: true` on the wire — a record external-dns asks us to write is by definition live.

## Tests

- `TestToDNSRecord_PerType/disabled_record_is_dropped` (new) — a valid-but-disabled A record converts to `ok=false`.
- `TestRecords_ExcludesDisabledRecords` (new) — a page with one enabled + one disabled record yields a single endpoint (the enabled one).
- Fixed the pre-existing `unknown type is dropped` case to set `Enabled: true`, so it still exercises the unknown-type path rather than short-circuiting on the new disabled check.
- Both new tests confirmed to **fail against pre-fix** (disabled record reported `ok=true` / appears in `Records`).
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 independent skeptics): 0 surviving findings. The recreate-on-disabled semantics were specifically scrutinized and accepted as the issue's chosen policy.

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)