### PR TITLE
fix(server): stop /readyz from leaking upstream detail to anonymous callers

### DIFF
--- a/internal/server/readiness.go
+++ b/internal/server/readiness.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -70,6 +71,15 @@ func (c *cachedProbe) Check(ctx context.Context) error {
 		pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), probeTimeout)
 		err := c.probe(pctx)
 		cancel()
+
+		if err != nil {
+			// Log the full cause here: /readyz returns only a generic "not
+			// ready" to its (possibly unauthenticated) caller, so the pod log is
+			// where operators see which upstream failed and why. Logging at the
+			// probe site rather than per request means one line per actual probe
+			// run, not one per cached /readyz hit. See #225.
+			slog.Warn("readiness probe failed", "error", err)
+		}
 
 		c.mu.Lock()
 		c.lastAt = time.Now()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,9 +113,15 @@ func readyzHandler(probe ProbeFunc, ttl time.Duration) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := cached.Check(r.Context()); err != nil {
+			// Return a generic body. The probe error chain embeds the UniFi
+			// host (and, in cloud mode, the console ID) plus a slice of the
+			// controller's error response; the health server listens on
+			// 0.0.0.0 with no auth, so echoing that to the caller leaks
+			// internal topology. The cause is logged server-side instead
+			// (see cachedProbe.Check). See #225.
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprintf(w, "not ready: %v\n", err)
+			_, _ = w.Write([]byte("not ready\n"))
 
 			return
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -108,7 +108,11 @@ func TestCachedProbe_DetachesFromCallerContext(t *testing.T) {
 }
 
 func TestReadyzHandler_ReturnsServiceUnavailableWhenProbeFails(t *testing.T) {
-	handler := readyzHandler(func(_ context.Context) error { return errors.New("nope") }, time.Minute)
+	// The cause embeds internal topology (UniFi host / console ID / upstream
+	// error body), so the response body to the unauthenticated caller must be
+	// generic and must NOT leak it. See #225.
+	const secret = "https://unifi.internal.example:8443 console-abc123 boom"
+	handler := readyzHandler(func(_ context.Context) error { return errors.New(secret) }, time.Minute)
 
 	rec := httptest.NewRecorder()
 	handler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
@@ -116,8 +120,12 @@ func TestReadyzHandler_ReturnsServiceUnavailableWhenProbeFails(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("status = %d, want 503", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "nope") {
-		t.Errorf("body should include cause; got %q", rec.Body.String())
+	body := rec.Body.String()
+	if strings.TrimSpace(body) != "not ready" {
+		t.Errorf("body = %q, want generic %q", body, "not ready")
+	}
+	if strings.Contains(body, secret) || strings.Contains(body, "unifi.internal") || strings.Contains(body, "console-abc123") {
+		t.Errorf("body leaked the probe error detail: %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `/readyz` handler echoed the probe error verbatim: `fmt.Fprintf(w, "not ready: %v\n", err)`. The probe is `provider.Records`, whose error chain embeds the UniFi controller host (and, in cloud mode, the Ubiquiti console ID) built from `Config.baseURL`, plus up to 512 bytes of the controller's own error response. The health server listens on `0.0.0.0:8080` with **no authentication**, so any pod or node-network neighbour could `curl /readyz` during an upstream failure and harvest that as recon material for pivoting toward the controller.

(API key is header-only, never in the URL — this is information disclosure, not credential theft, and only during active upstream failure.)

## Fix

Return a generic `not ready` body to the caller, and log the full cause **server-side** instead — inside `cachedProbe.Check` at the probe site, so it's one log line per actual probe run, not one per cached `/readyz` hit. Operators still see which upstream failed and why, in the pod log.

The bind address is intentionally left at `0.0.0.0`: Kubernetes HTTP probes connect to the **pod IP**, so a localhost-only default would break readiness/liveness checks entirely. Restricting reachability of the port is a `NetworkPolicy` concern, not a bind-address one.

## Tests

- `TestReadyzHandler_ReturnsServiceUnavailableWhenProbeFails` updated: the 503 body must be exactly `not ready` and must **not** contain the host / console ID / error detail.
- Confirmed to **fail against pre-fix** (body was `not ready: https://unifi.internal.example:8443 console-abc123 boom`).
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 independent skeptics): 0 surviving findings. The "is the cause still observable on cache-hit failures?" and "0.0.0.0 bind kept" angles were specifically scrutinized.

Fixes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)