### PR TITLE
fix(unifi): clear controller-managed TTL on TXT/MX/SRV to stop reconcile churn

### DIFF
--- a/internal/unifi/dto.go
+++ b/internal/unifi/dto.go
@@ -155,6 +155,9 @@ func fromDNSRecord(r DNSRecord) (dnsPolicyEnvelope, error) {
 		env.Type = policyTypeCNAME
 		env.TargetDomain = r.Value
 		env.TTLSeconds = new(clampTTL(int(r.TTL), ttlMaxCNAME))
+	// TXT/MX/SRV deliberately send no TTLSeconds: the Integration API manages
+	// their TTL itself and ignores any value. AdjustEndpoints clears the TTL
+	// from the desired set so external-dns doesn't churn over it. See #229.
 	case recordTypeTXT:
 		env.Type = policyTypeTXT
 		env.Text = r.Value

--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -62,6 +62,35 @@ func NewUnifiProvider(config *Config) (provider.Provider, error) {
 	}, nil
 }
 
+// recordTypesWithoutCustomTTL are the record types whose TTL the UniFi
+// Integration API manages itself: it ignores any ttlSeconds sent for them, and
+// only A/AAAA/CNAME honour a custom value. fromDNSRecord already omits the TTL
+// on writes for these; AdjustEndpoints clears it from the desired set so it
+// can't drive perpetual reconcile churn. See #229.
+var recordTypesWithoutCustomTTL = map[string]struct{}{
+	recordTypeTXT: {},
+	recordTypeMX:  {},
+	recordTypeSRV: {},
+}
+
+// AdjustEndpoints canonicalises the desired endpoints to what the UniFi
+// controller can actually represent. The Integration API manages the TTL for
+// TXT, MX, and SRV records itself and ignores any value sent for them. If a
+// user-set TTL is left on such an endpoint, external-dns compares it against
+// the controller-managed TTL on every reconcile, never reaches equality, and
+// churns delete+create forever. Clearing the TTL here makes the desired state
+// match what the controller will store, so the record converges. A/AAAA/CNAME
+// (which do honour a custom TTL) are left untouched. See #229.
+func (p *UnifiProvider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.Endpoint, error) {
+	for _, ep := range endpoints {
+		if _, managed := recordTypesWithoutCustomTTL[ep.RecordType]; managed {
+			ep.RecordTTL = 0
+		}
+	}
+
+	return endpoints, nil
+}
+
 // Records returns the list of records in the DNS provider.
 func (p *UnifiProvider) Records(ctx context.Context) (_ []*endpoint.Endpoint, err error) {
 	m := metrics.Get()

--- a/internal/unifi/provider_test.go
+++ b/internal/unifi/provider_test.go
@@ -281,3 +281,43 @@ func TestRecords_ExcludesDisabledRecords(t *testing.T) {
 		t.Errorf("endpoint = %q, want on.example.com (the enabled record)", eps[0].DNSName)
 	}
 }
+
+// TestAdjustEndpoints_ClearsTTLForControllerManagedTypes is the #229
+// regression: the UniFi API manages (and ignores a custom) TTL for TXT/MX/SRV,
+// so a user-set TTL on those types must be stripped from the desired set or
+// external-dns churns delete+create forever. A/AAAA/CNAME keep their TTL.
+func TestAdjustEndpoints_ClearsTTLForControllerManagedTypes(t *testing.T) {
+	p := &UnifiProvider{}
+	in := []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("a.example.com", recordTypeA, 300, "192.0.2.1"),
+		endpoint.NewEndpointWithTTL("v6.example.com", recordTypeAAAA, 300, "2001:db8::1"),
+		endpoint.NewEndpointWithTTL("alias.example.com", recordTypeCNAME, 300, "target.example.com"),
+		endpoint.NewEndpointWithTTL("txt.example.com", recordTypeTXT, 300, "v=spf1 ~all"),
+		endpoint.NewEndpointWithTTL("example.com", recordTypeMX, 300, "10 mail.example.com"),
+		endpoint.NewEndpointWithTTL("_ldap._tcp.example.com", recordTypeSRV, 300, "10 20 389 ldap.example.com"),
+	}
+
+	out, err := p.AdjustEndpoints(in)
+	if err != nil {
+		t.Fatalf("AdjustEndpoints: %v", err)
+	}
+
+	byType := make(map[string]*endpoint.Endpoint, len(out))
+	for _, ep := range out {
+		byType[ep.RecordType] = ep
+	}
+
+	// A/AAAA/CNAME honour a custom TTL — it must survive.
+	for _, ty := range []string{recordTypeA, recordTypeAAAA, recordTypeCNAME} {
+		if got := byType[ty].RecordTTL; got != 300 {
+			t.Errorf("%s TTL = %v, want 300 preserved", ty, got)
+		}
+	}
+	// TXT/MX/SRV are controller-managed — the TTL must be cleared so it is no
+	// longer "configured" (the trigger for external-dns TTL churn).
+	for _, ty := range []string{recordTypeTXT, recordTypeMX, recordTypeSRV} {
+		if byType[ty].RecordTTL.IsConfigured() {
+			t.Errorf("%s TTL = %v, want cleared (controller-managed)", ty, byType[ty].RecordTTL)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The UniFi Integration API **manages the TTL for TXT, MX, and SRV records itself and ignores any `ttlSeconds` sent for them** — only A/AAAA/CNAME honour a custom TTL ([Ubiquiti Help Center](https://help.ui.com/hc/en-us/articles/15179064940439-UniFi-DNS-Records-and-Local-Hostnames), [Pulumi UniFi provider](https://www.pulumi.com/registry/packages/unifi/api-docs/dns/record/)). `fromDNSRecord` already omits the TTL on writes for those types, but external-dns still carries the user's desired TTL into the plan. Every reconcile it compares that desired TTL against the controller-managed one, never reaches equality, and queues a delete+create — **perpetual churn** whenever a TTL is set on a TXT/MX/SRV record (including external-dns's own ownership TXT registry records).

## Fix

Override `AdjustEndpoints` (the provider canonicalisation hook, called by external-dns on the desired set before planning) to clear `RecordTTL` on TXT/MX/SRV endpoints, so the desired state matches what the controller will actually store. A/AAAA/CNAME are untouched.

**Why not send the TTL on writes** (the issue's first suggestion): the API ignores `ttlSeconds` for these types, so it would not change what the controller stores and the desired-vs-current mismatch — the real cause of the churn — would remain. Adjusting the desired endpoints is the correct layer.

## Tests

- `TestAdjustEndpoints_ClearsTTLForControllerManagedTypes` (new): A/AAAA/CNAME keep TTL=300; TXT/MX/SRV come back with `RecordTTL.IsConfigured() == false`.
- Confirmed to **fail against pre-fix** (the inherited `BaseProvider.AdjustEndpoints` leaves all TTLs at 300).
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 skeptics). One finding — the test claimed to cover AAAA but didn't — was confirmed and fixed (an AAAA endpoint is now created and asserted preserved).

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)