### PR TITLE
fix(metrics): bound the HTTP endpoint label to matched routes

### DIFF
--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -2,10 +2,32 @@ package metrics
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/home-operations/external-dns-unifi-webhook/internal/httpx"
 )
+
+// RouteLabel reduces a request to a bounded metric label: the matched route's
+// template path, or "other" for any request that did not match a registered
+// route (a 404). Using r.Pattern (set by http.ServeMux during routing) rather
+// than r.URL.Path keeps the label cardinality bounded by the number of
+// registered routes — even a 404 flood, or a subtree pattern like
+// "GET /debug/pprof/" whose request paths vary, collapses to a single series.
+//
+// r.Pattern is only populated after the request has been routed, so callers
+// must invoke this AFTER next.ServeHTTP.
+func RouteLabel(r *http.Request) string {
+	if r.Pattern == "" {
+		return "other"
+	}
+	// r.Pattern is "[METHOD ][HOST]/path"; the path begins at the first slash.
+	if i := strings.IndexByte(r.Pattern, '/'); i >= 0 {
+		return r.Pattern[i:]
+	}
+
+	return "other"
+}
 
 // HTTPMetricsMiddleware records request count, duration, in-flight count and
 // response size for every wrapped HTTP handler.
@@ -21,6 +43,6 @@ func HTTPMetricsMiddleware(next http.Handler) http.Handler {
 
 		next.ServeHTTP(rec, r)
 
-		m.RecordHTTPRequest(r.Method, r.URL.Path, rec.Status(), time.Since(start), rec.Written())
+		m.RecordHTTPRequest(r.Method, RouteLabel(r), rec.Status(), time.Since(start), rec.Written())
 	})
 }

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestRouteLabel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		pattern string
+		want    string
+	}{
+		{"GET /records", "/records"},
+		{"POST /adjustendpoints", "/adjustendpoints"},
+		{"GET /", "/"},
+		{"GET /debug/pprof/", "/debug/pprof/"}, // subtree pattern: bounded despite varying request paths
+		{"/records", "/records"},               // no method prefix
+		{"", "other"},                          // unmatched (404)
+	}
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			t.Parallel()
+			if got := RouteLabel(&http.Request{Pattern: tt.pattern}); got != tt.want {
+				t.Errorf("RouteLabel(pattern=%q) = %q, want %q", tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHTTPMetricsMiddleware_BoundsEndpointLabel is the #224 regression: requests
+// to unmatched paths must all collapse to a single endpoint="other" label
+// instead of minting a new series per raw path (unbounded cardinality), while a
+// matched route keeps its template path.
+func TestHTTPMetricsMiddleware_BoundsEndpointLabel(t *testing.T) {
+	m := Get()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /records", func(http.ResponseWriter, *http.Request) {})
+	h := HTTPMetricsMiddleware(mux)
+
+	count := func(endpoint, code string) float64 {
+		var dm dto.Metric
+		_ = m.HTTPRequestsTotal.WithLabelValues(ProviderName, http.MethodGet, endpoint, code).Write(&dm)
+
+		return dm.GetCounter().GetValue()
+	}
+
+	// Three distinct unmatched paths must all land on endpoint="other".
+	before := count("other", "404")
+	for _, p := range []string{"/nope-a", "/nope-b", "/nope-c"} {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, p, nil))
+	}
+	if got := count("other", "404") - before; got != 3 {
+		t.Errorf(`endpoint="other"{404} delta = %v, want 3 (every unmatched path collapses to one series)`, got)
+	}
+
+	// A matched route is recorded under its template path.
+	beforeMatched := count("/records", "200")
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/records", nil))
+	if got := count("/records", "200") - beforeMatched; got != 1 {
+		t.Errorf(`endpoint="/records"{200} delta = %v, want 1`, got)
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -25,7 +25,7 @@ func recoveryAndAccessLog(next http.Handler) http.Handler {
 
 		defer func() {
 			if rv := recover(); rv != nil {
-				metrics.Get().PanicsTotal.WithLabelValues(metrics.ProviderName, r.URL.Path).Inc()
+				metrics.Get().PanicsTotal.WithLabelValues(metrics.ProviderName, metrics.RouteLabel(r)).Inc()
 				slog.Error("panic in HTTP handler",
 					"panic", rv,
 					"method", r.Method,


### PR DESCRIPTION
## Summary

`HTTPMetricsMiddleware` labelled `http_requests_total` / `_duration_seconds` / `_response_size_bytes` by raw `r.URL.Path`, and `recoveryAndAccessLog` labelled `http_handler_panics_total` the same way. Any unmatched path — a 404 probe, a port scanner, a typo'd URL — minted a brand-new label series. An unauthenticated 404 flood is therefore an **unbounded-cardinality denial-of-service against Prometheus** (memory blowup in the scrape target and TSDB).

## Fix

Add `metrics.RouteLabel(r)`, which uses `r.Pattern` (set by `http.ServeMux` during routing) to report the **matched route's template path**, collapsing everything unmatched to a single `other` series. Both middlewares read it after `ServeHTTP`, where `r.Pattern` is populated (the mux sets it before dispatching, so it's available even on the panic-recovery path).

Using the pattern rather than `r.URL.Path` also bounds subtree patterns like `GET /debug/pprof/`, whose request paths vary, to one series.

The known static routes (`/`, `/records`, `/adjustendpoints`, `/healthz`, `/readyz`, `/metrics`) keep their existing path label, so dashboards are unaffected; only unmatched paths change (now `other`).

## Tests

- `TestRouteLabel` (new): table over `GET /records` → `/records`, `GET /` → `/`, subtree `GET /debug/pprof/` → `/debug/pprof/`, no-method `/records`, and unmatched `""` → `other`.
- `TestHTTPMetricsMiddleware_BoundsEndpointLabel` (new): three distinct unmatched paths all increment the single `endpoint="other"` `{404}` series (delta 3), while a matched `GET /records` records under `/records`. Under the old `r.URL.Path` behaviour the `other` series would never have moved.
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 skeptics): 0 surviving findings.

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)