### PR TITLE
fix(unifi): guard backoff jitter against a panicking divisor

### DIFF
--- a/internal/unifi/transport.go
+++ b/internal/unifi/transport.go
@@ -200,7 +200,13 @@ func (c *httpClient) backoff(attempt int, hint time.Duration) time.Duration {
 		base = maxDelay
 	}
 	// 0-50% jitter so concurrent workers don't all retry on the same tick.
-	jitter := time.Duration(rand.Int64N(int64(base) / 2))
+	// Guard the divisor: rand.Int64N panics on a non-positive argument, which
+	// base/2 would be for a sub-2ns base (config validation floors the initial
+	// delay at 1ms, but backoff stays self-contained).
+	var jitter time.Duration
+	if half := int64(base) / 2; half > 0 {
+		jitter = time.Duration(rand.Int64N(half))
+	}
 	wait := base + jitter
 
 	if hint > 0 && hint > wait {

--- a/internal/unifi/transport_test.go
+++ b/internal/unifi/transport_test.go
@@ -236,6 +236,21 @@ func TestBackoff_ClampsToMax(t *testing.T) {
 	}
 }
 
+// TestBackoff_NoPanicOnSubTwoNanoDelay is the #230 regression: a sub-2ns
+// initial delay makes base/2 == 0, and rand.Int64N panics on a non-positive
+// argument. backoff must guard the divisor and still return a sane wait.
+func TestBackoff_NoPanicOnSubTwoNanoDelay(t *testing.T) {
+	c := &httpClient{cfg: &Config{
+		RetryInitialDelay: 1 * time.Nanosecond,
+		RetryMaxDelay:     1 * time.Second,
+	}}
+
+	got := c.backoff(0, 0) // base = 1ns, base/2 = 0 → would panic pre-fix
+	if got < 0 {
+		t.Errorf("backoff returned negative wait %v", got)
+	}
+}
+
 func TestWorstCaseRetryBudget(t *testing.T) {
 	// The bound is (attempts-1) * RetryMaxDelay: each of the attempts-1 waits
 	// can be driven to RetryMaxDelay by a 429 Retry-After hint, so the initial

--- a/internal/unifi/types.go
+++ b/internal/unifi/types.go
@@ -17,6 +17,11 @@ import (
 const (
 	maxApplyWorkers  = 100
 	maxRetryAttempts = 10
+	// minRetryInitialDelay floors UNIFI_RETRY_INITIAL_DELAY. backoff() computes
+	// jitter as rand.Int64N(base/2); a sub-2ns initial delay makes base/2 == 0,
+	// which panics rand.Int64N. 1ms is far below any sensible retry delay (the
+	// default is 500ms) while keeping base/2 safely positive.
+	minRetryInitialDelay = time.Millisecond
 )
 
 // Config represents the configuration for the UniFi API.
@@ -80,8 +85,8 @@ func (c Config) Validate() error {
 	if c.ApplyWorkers < 1 || c.ApplyWorkers > maxApplyWorkers {
 		return fmt.Errorf("UNIFI_APPLY_WORKERS must be between 1 and %d, got %d", maxApplyWorkers, c.ApplyWorkers)
 	}
-	if c.RetryInitialDelay <= 0 {
-		return fmt.Errorf("UNIFI_RETRY_INITIAL_DELAY must be positive, got %s", c.RetryInitialDelay)
+	if c.RetryInitialDelay < minRetryInitialDelay {
+		return fmt.Errorf("UNIFI_RETRY_INITIAL_DELAY must be >= %s, got %s", minRetryInitialDelay, c.RetryInitialDelay)
 	}
 	if c.RetryMaxDelay < c.RetryInitialDelay {
 		return fmt.Errorf("UNIFI_RETRY_MAX_DELAY (%s) must be >= UNIFI_RETRY_INITIAL_DELAY (%s)",

--- a/internal/unifi/types_test.go
+++ b/internal/unifi/types_test.go
@@ -33,6 +33,11 @@ func TestConfigValidate(t *testing.T) {
 		{"apply workers zero", func(c *Config) { c.ApplyWorkers = 0 }, true},
 		{"apply workers too high", func(c *Config) { c.ApplyWorkers = maxApplyWorkers + 1 }, true},
 		{"initial delay zero", func(c *Config) { c.RetryInitialDelay = 0 }, true},
+		{"initial delay below floor", func(c *Config) { c.RetryInitialDelay = time.Nanosecond }, true},
+		{"initial delay at floor", func(c *Config) {
+			c.RetryInitialDelay = minRetryInitialDelay
+			c.RetryMaxDelay = minRetryInitialDelay
+		}, false},
 		{"max delay below initial", func(c *Config) { c.RetryMaxDelay = 100 * time.Millisecond }, true},
 		{"cloud host without console id", func(c *Config) { c.Host = "https://api.ui.com" }, true},
 		{"cloud host with console id", func(c *Config) {


### PR DESCRIPTION
## Summary

`backoff()` computes jitter as `rand.Int64N(int64(base) / 2)`. For a sub-2ns `base` — reachable when `UNIFI_RETRY_INITIAL_DELAY` is set to `1ns`, since `Validate` only required `> 0` — `base/2` truncates to `0`, and `rand.Int64N` panics on a non-positive argument, crashing the retry path on the first backoff.

## Fix

- Floor `UNIFI_RETRY_INITIAL_DELAY` at `1ms` in `Config.Validate` (`minRetryInitialDelay`) — far below the `500ms` default, so no realistic config is affected.
- Additionally guard the divisor in `backoff` so it is panic-free regardless of how it's called (defense in depth; `backoff` stays self-contained).

## Tests

- `TestConfigValidate` gains "initial delay below floor" (`1ns` → rejected) and "initial delay at floor" (`1ms` → accepted).
- `TestBackoff_NoPanicOnSubTwoNanoDelay` calls `backoff(0, 0)` with a `1ns` initial delay; it **panics pre-fix** (`invalid argument to Int64N`) and returns a sane wait after.
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 skeptics): 0 surviving findings.

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)