### PR TITLE
fix(unifi): account for the create-endpoint response body size

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -231,8 +231,9 @@ func (c *httpClient) fetchPolicyPage(ctx context.Context, offset, limit int) (dn
 func (c *httpClient) CreateEndpoint(ctx context.Context, endpoint *externaldnsendpoint.Endpoint) (created []*DNSRecord, err error) {
 	m := metrics.Get()
 	start := time.Now()
+	var bodyRead int
 	defer func() {
-		m.RecordUniFiAPICall("create_endpoint", time.Since(start), 0, err)
+		m.RecordUniFiAPICall("create_endpoint", time.Since(start), bodyRead, err)
 	}()
 
 	if endpoint.RecordType == recordTypeCNAME && len(endpoint.Targets) > 1 {
@@ -251,7 +252,8 @@ func (c *httpClient) CreateEndpoint(ctx context.Context, endpoint *externaldnsen
 			Value:      target,
 		}
 
-		out, cerr := c.createOne(ctx, r)
+		n, out, cerr := c.createOne(ctx, r)
+		bodyRead += n
 		if cerr != nil {
 			if isSRVConversionError(cerr) {
 				m.SRVParsingErrorsTotal.WithLabelValues(metrics.ProviderName).Inc()
@@ -274,35 +276,38 @@ func isSRVConversionError(err error) bool {
 	return errors.Is(err, errSRVConversion)
 }
 
-func (c *httpClient) createOne(ctx context.Context, r DNSRecord) (*DNSRecord, error) {
+// createOne POSTs a single DNS record and returns the number of response body
+// bytes read (for metric accounting), the created record, and any error.
+func (c *httpClient) createOne(ctx context.Context, r DNSRecord) (int, *DNSRecord, error) {
 	env, err := fromDNSRecord(r)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 
 	body, err := json.Marshal(env)
 	if err != nil {
-		return nil, NewDataError("marshal", "DNS record", err)
+		return 0, nil, NewDataError("marshal", "DNS record", err)
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, formatURL(pathPolicies, c.cfg.baseURL(), c.siteID), body)
 	if err != nil {
-		return nil, fmt.Errorf("creating DNS record: %w", err)
+		return 0, nil, fmt.Errorf("creating DNS record: %w", err)
 	}
 	defer extdnshttp.DrainAndClose(resp.Body)
 
 	var createdEnv dnsPolicyEnvelope
-	if _, err := decodeJSON(resp, "created DNS record", &createdEnv); err != nil {
-		return nil, err
+	n, err := decodeJSON(resp, "created DNS record", &createdEnv)
+	if err != nil {
+		return n, nil, err
 	}
 
 	out, ok := toDNSRecord(createdEnv)
 	if !ok {
-		return nil, NewDataError("convert", "created DNS record",
+		return n, nil, NewDataError("convert", "created DNS record",
 			fmt.Errorf("unsupported response type %q", createdEnv.Type))
 	}
 
-	return &out, nil
+	return n, &out, nil
 }
 
 // DeleteRecord deletes a single DNS record by its ID. 404 responses are

--- a/internal/unifi/client_test.go
+++ b/internal/unifi/client_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/home-operations/external-dns-unifi-webhook/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/external-dns/endpoint"
 )
 
@@ -708,5 +710,51 @@ func TestDecodeJSON_AcceptsBodyAtLimit(t *testing.T) {
 	var dest dnsPolicyPage
 	if _, err := decodeJSON(resp, "DNS policies", &dest); err != nil {
 		t.Fatalf("body exactly at the limit should decode, got: %v", err)
+	}
+}
+
+// TestCreateEndpoint_RecordsResponseSize is the #226 regression: the create
+// path must report the decoded response-body size to the UniFi response-size
+// histogram. It previously hardcoded 0, so the create_endpoint operation never
+// contributed a sample.
+func TestCreateEndpoint_RecordsResponseSize(t *testing.T) {
+	// Echo the posted envelope back as the created record so decodeJSON reads a
+	// non-empty, well-formed body.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	// HistogramVec.WithLabelValues returns an Observer; the concrete child also
+	// implements prometheus.Metric, which is what exposes Write for readback.
+	hist, ok := metrics.Get().UniFiResponseSizeBytes.WithLabelValues("create_endpoint").(prometheus.Metric)
+	if !ok {
+		t.Fatal("response-size histogram child is not a prometheus.Metric")
+	}
+	read := func() (uint64, float64) {
+		t.Helper()
+		var dm dto.Metric
+		if err := hist.Write(&dm); err != nil {
+			t.Fatalf("histogram.Write: %v", err)
+		}
+
+		return dm.GetHistogram().GetSampleCount(), dm.GetHistogram().GetSampleSum()
+	}
+
+	beforeCount, beforeSum := read()
+	ep := endpoint.NewEndpointWithTTL("a.example.com", recordTypeA, 300, "192.0.2.1")
+	if _, err := c.CreateEndpoint(context.Background(), ep); err != nil {
+		t.Fatalf("CreateEndpoint: %v", err)
+	}
+	afterCount, afterSum := read()
+
+	if afterCount != beforeCount+1 {
+		t.Errorf("response-size sample count delta = %d, want 1 (create path observed nothing)", afterCount-beforeCount)
+	}
+	if afterSum <= beforeSum {
+		t.Errorf("response-size sum did not grow (%v -> %v); create path still reports 0 bytes", beforeSum, afterSum)
 	}
 }


### PR DESCRIPTION
## Summary

`CreateEndpoint` passed a hardcoded `0` as the response size to `RecordUniFiAPICall`, so the `create_endpoint` operation never contributed a sample to the `unifi_response_size_bytes` histogram (which only observes when size > 0) — leaving the create path invisible in that metric. `createOne` already had the byte count from `decodeJSON` but discarded it.

## Fix

Return the decoded byte count from `createOne` (`(int, *DNSRecord, error)`) and accumulate it across targets in `CreateEndpoint`, passing the total to `RecordUniFiAPICall` — matching the pattern `GetEndpoints` already uses.

## Tests

- `TestCreateEndpoint_RecordsResponseSize` (new): an echo server returns a known-size body; the `create_endpoint` response-size histogram gains exactly one sample with a non-zero sum. **Fails pre-fix** (count delta 0, sum 0).
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 skeptics): 0 surviving findings.

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)