### PR TITLE
fix(webhook): log AdjustEndpoints errors; drop no-op Negotiate WriteHeader

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -100,6 +100,7 @@ func (p *Webhook) AdjustEndpoints(w http.ResponseWriter, r *http.Request) {
 
 	endpoints, err := p.provider.AdjustEndpoints(endpoints)
 	if err != nil {
+		requestLog(r).Error("adjusting endpoints", "error", err)
 		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusInternalServerError)
 
@@ -120,8 +121,11 @@ func (p *Webhook) Negotiate(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(contentTypeHeader, string(mediaTypeVersion1))
 	if err := json.NewEncoder(w).Encode(p.provider.GetDomainFilter()); err != nil {
+		// The encoder has already written (and implicitly flushed a 200) by the
+		// time it can fail, so a WriteHeader(500) here is a no-op that only logs
+		// a "superfluous WriteHeader" warning. Just record the cause, matching
+		// writeJSON. See #228.
 		requestLog(r).Error("encoding negotiate response", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -265,5 +266,70 @@ func TestNegotiate_MissingAccept(t *testing.T) {
 
 	if rec.Code != http.StatusNotAcceptable {
 		t.Errorf("status = %d, want 406", rec.Code)
+	}
+}
+
+// TestAdjustEndpoints_ProviderError is the #227 regression: a provider error
+// from AdjustEndpoints must be logged (matching the Records / ApplyChanges
+// handlers), not silently turned into a bare 500.
+func TestAdjustEndpoints_ProviderError(t *testing.T) {
+	// Not parallel: captures the global slog default.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(prev)
+
+	wh := New(&fakeProvider{adjustErr: errors.New("boom")})
+	body, _ := json.Marshal([]*endpoint.Endpoint{endpoint.NewEndpoint("a.example.com", "A", "1.2.3.4")})
+
+	rec := httptest.NewRecorder()
+	wh.AdjustEndpoints(rec, newRequest(http.MethodPost, "/adjustendpoints", body, map[string]string{
+		"Content-Type": string(mediaTypeVersion1),
+		"Accept":       string(mediaTypeVersion1),
+	}))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(buf.String(), "adjusting endpoints") {
+		t.Errorf("AdjustEndpoints provider error was not logged; log = %q", buf.String())
+	}
+}
+
+// recordingFailWriter fails every Write and records WriteHeader codes, so a
+// test can prove a handler does not attempt a (no-op, superfluous) WriteHeader
+// after the response is already committed.
+type recordingFailWriter struct {
+	header http.Header
+	codes  []int
+}
+
+func (w *recordingFailWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+
+	return w.header
+}
+func (w *recordingFailWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
+func (w *recordingFailWriter) WriteHeader(code int)      { w.codes = append(w.codes, code) }
+
+// TestNegotiate_NoSuperfluousWriteHeaderOnEncodeError is the #228 regression:
+// once the JSON encoder has started writing (committing a 200), a later
+// WriteHeader(500) is a no-op that only logs a "superfluous WriteHeader"
+// warning. Negotiate must not make that call.
+func TestNegotiate_NoSuperfluousWriteHeaderOnEncodeError(t *testing.T) {
+	t.Parallel()
+	wh := New(&fakeProvider{})
+
+	w := &recordingFailWriter{}
+	wh.Negotiate(w, newRequest(http.MethodGet, "/", nil, map[string]string{
+		"Accept": string(mediaTypeVersion1),
+	}))
+
+	for _, c := range w.codes {
+		if c == http.StatusInternalServerError {
+			t.Errorf("Negotiate called WriteHeader(500) after the response was committed (superfluous)")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Two webhook handler error-path fixes:

- **#227** — `AdjustEndpoints` returned `500` on a provider error without logging the cause, unlike the `Records` and `ApplyChanges` handlers. Operators saw only the access log's status line, never the reason. Added the matching `requestLog(r).Error("adjusting endpoints", "error", err)`. (Now that the UniFi provider implements a real `AdjustEndpoints` — TTL canonicalisation, #229 — this path is no longer purely latent.)
- **#228** — `Negotiate` called `WriteHeader(500)` after `json.Encode` failed, but the encoder has already written and implicitly flushed a `200` by then, so the call is a no-op that only logs `http: superfluous response.WriteHeader call`. Dropped it; the cause is logged, matching `writeJSON`.

## Tests

- `TestAdjustEndpoints_ProviderError` (new): captures slog output and asserts the `"adjusting endpoints"` error is logged alongside the 500. **Fails pre-fix** (empty log).
- `TestNegotiate_NoSuperfluousWriteHeaderOnEncodeError` (new): a Write-failing ResponseWriter records `WriteHeader` codes; asserts no `500` is written after the response is committed. **Fails pre-fix** (records the superfluous 500).
- `go test ./...` green; `golangci-lint run` 0 issues.

> Adversarially reviewed (find → 2 skeptics): 0 surviving findings.

Fixes #227
Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)