### PR TITLE
ci: surface test coverage total in the run summary

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,3 +47,22 @@ jobs:
 
       - name: Run unit tests
         run: mise run test
+
+      # Surface the total coverage that `mise run test` already computes into
+      # cover.out — it was otherwise generated and discarded. Reported only (no
+      # threshold gate): a minimum-coverage policy is the maintainer's call.
+      - name: Report coverage
+        run: |
+          set -o pipefail
+          if [ ! -f cover.out ]; then
+            echo "cover.out missing; the test step did not produce a coverage profile" >&2
+            exit 1
+          fi
+          total="$(go tool cover -func=cover.out | tail -1)"
+          echo "$total"
+          {
+            echo "### Coverage"
+            echo '```'
+            echo "$total"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The `test` task generates `cover.out` via `go test -coverprofile`, but the workflow never used it — coverage was computed and discarded. Add a **Report coverage** step that prints the total (`go tool cover -func`) to the log and the GitHub step summary so it's visible per run.

**Reported only, deliberately not gated.** Imposing a minimum-coverage threshold is a maintainer policy decision, and a wrong number would just wedge CI — so this PR only surfaces the number.

The step is hardened (per adversarial review): explicit `set -o pipefail` plus a `cover.out` existence guard, so it fails loudly with a clear message rather than ever writing a misleading empty/garbage coverage block.

## Notes

- CI-only change (no Go code), so no unit test; the workflow run itself exercises the new step.
- Passes the repo's `zizmor` and `format-yaml` pre-commit hooks; the shell is shellcheck-clean.

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)