### PR TITLE
build: standardize on the distroless/static:nonroot base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:${GO_VERSION}-alpine AS builder
 ARG VERSION=dev
 ARG REVISION=dev
 WORKDIR /src
-RUN apk add --no-cache upx && \
-    echo 'nobody:x:65534:65534:Nobody:/:' > /tmp/passwd
+RUN apk add --no-cache upx
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
@@ -13,10 +12,7 @@ RUN CGO_ENABLED=0 go build \
     -trimpath -o /out/external-dns-unifi-webhook ./cmd/external-dns-unifi-webhook
 RUN upx --best --lzma /out/external-dns-unifi-webhook
 
-FROM scratch
-COPY --from=builder /tmp/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+FROM gcr.io/distroless/static:nonroot
 COPY --from=builder /out/external-dns-unifi-webhook /external-dns-unifi-webhook
-USER 65534
 EXPOSE 8888/tcp
 ENTRYPOINT ["/external-dns-unifi-webhook"]


### PR DESCRIPTION
Standardizes the image on the fleet base — **`gcr.io/distroless/static:nonroot`** runtime, built from a `golang-alpine` (+ `node-alpine` where the UI build needs it) builder with `upx` compression.

- **Runtime → `gcr.io/distroless/static:nonroot`** — it bundles CA certs, `/etc/passwd`, and a nonroot user (uid/gid **65532**), so the hand-rolled `COPY ca-certificates.crt` / `/etc/passwd` and the `USER` directive are dropped; the base provides them.
- **Builder → `golang:${GO_VERSION}-alpine`** (and `node:${NODE_VERSION}-alpine` where used), with `upx --best --lzma` on the binary — now consistent across the fleet.
- **Chart `podSecurityContext`** pins `runAsUser`/`runAsGroup`/`fsGroup: 65532` to match the base (where this repo ships a chart).

No behavior change — the static binary runs identically. Verified locally: the alpine-built, upx-compressed binary builds and serves on `distroless/static:nonroot`.
