### PR TITLE
feat: move the metrics/health server to 8081

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Configure `--domain-filter` (and its variants) on the **ExternalDNS controller**
 | `SERVER_IDLE_TIMEOUT`        | Keep-alive idle timeout.                                   | `120s`            |
 | `SERVER_MAX_HEADER_BYTES`    | Maximum request header size.                               | `65536`           |
 | `SERVER_MAX_BODY_BYTES`      | Maximum POST body size before returning `413`.             | `5242880` (5 MiB) |
-| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `0.0.0.0:8080`    |
+| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `0.0.0.0:8081`    |
 | `READINESS_CACHE_TTL`        | How long `/readyz` caches the upstream probe result.       | `30s`             |
 | `PPROF_ENABLED`              | Mount `/debug/pprof/*` on the health server (not in prod). | `false`           |
 | `LOG_LEVEL`                  | Log verbosity: `debug`, `info`, `warn`, `error`.           | `info`            |
@@ -171,10 +171,10 @@ Configure `--domain-filter` (and its variants) on the **ExternalDNS controller**
 | --------------- | -------------- | ----------------------------------------------------------- |
 | `/`             | `8888`         | ExternalDNS negotiate (returns the provider media type).    |
 | `/records`      | `8888`         | ExternalDNS `GET` (list) and `POST` (apply changes).        |
-| `/healthz`      | `8888`, `8080` | Liveness — `200 OK` while the process is running.           |
-| `/readyz`       | `8888`, `8080` | Readiness — probes UniFi, cached for `READINESS_CACHE_TTL`. |
-| `/metrics`      | `8080`         | Prometheus metrics.                                         |
-| `/debug/pprof/` | `8080`         | Go pprof endpoints (only when `PPROF_ENABLED=true`).        |
+| `/healthz`      | `8888`, `8081` | Liveness — `200 OK` while the process is running.           |
+| `/readyz`       | `8888`, `8081` | Readiness — probes UniFi, cached for `READINESS_CACHE_TTL`. |
+| `/metrics`      | `8081`         | Prometheus metrics.                                         |
+| `/debug/pprof/` | `8081`         | Go pprof endpoints (only when `PPROF_ENABLED=true`).        |
 
 `/healthz` and `/readyz` are served on both ports so Kubernetes probes can target the webhook port directly without exposing a second container port through the chart.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	ServerIdleTimeout       time.Duration `env:"SERVER_IDLE_TIMEOUT"        envDefault:"120s"`
 	ServerMaxHeaderBytes    int           `env:"SERVER_MAX_HEADER_BYTES"    envDefault:"65536"`
 	ServerMaxBodyBytes      int64         `env:"SERVER_MAX_BODY_BYTES"      envDefault:"5242880"`
-	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:"0.0.0.0:8080"`
+	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:"0.0.0.0:8081"`
 	ReadinessCacheTTL       time.Duration `env:"READINESS_CACHE_TTL"        envDefault:"30s"`
 	PprofEnabled            bool          `env:"PPROF_ENABLED"              envDefault:"false"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,7 @@ func validConfig() Config {
 		ServerMaxBodyBytes:   5 << 20,
 		ServerMaxHeaderBytes: 1 << 16,
 		ServerReadTimeout:    60 * time.Second,
-		HealthServerAddr:     "0.0.0.0:8080",
+		HealthServerAddr:     "0.0.0.0:8081",
 	}
 }
 
@@ -60,8 +60,8 @@ func TestInit_Defaults(t *testing.T) {
 	if cfg.ServerPort != 8888 {
 		t.Errorf("ServerPort = %d, want 8888", cfg.ServerPort)
 	}
-	if cfg.HealthServerAddr != "0.0.0.0:8080" {
-		t.Errorf("HealthServerAddr = %q, want 0.0.0.0:8080", cfg.HealthServerAddr)
+	if cfg.HealthServerAddr != "0.0.0.0:8081" {
+		t.Errorf("HealthServerAddr = %q, want 0.0.0.0:8081", cfg.HealthServerAddr)
 	}
 }
 


### PR DESCRIPTION
## What

Move the standalone monitoring server (`HEALTH_SERVER_ADDR`, serving `/metrics`, `/healthz`, `/readyz`, and `/debug/pprof/`) from its default port `8080` to **`8081`**.

## Why

Frees up `8080` and aligns the monitoring server on a dedicated, non-conflicting port.

## Details

- `HEALTH_SERVER_ADDR` default changed from `0.0.0.0:8080` → `0.0.0.0:8081` (`internal/config/config.go`).
- Config test assertions updated to match the new default (`internal/config/config_test.go`).
- README env table and endpoint table updated (`/metrics`, `/healthz`, `/readyz`, `/debug/pprof/`) to reflect `8081`.

## Unchanged

- The ExternalDNS webhook API on `SERVER_PORT` **`8888`** is untouched.
- `/healthz` and `/readyz` remain **dual-served on `8888`** as well, so Kubernetes probes can still target the webhook port directly — only the standalone monitoring server moved.

## Verification

- `go build ./...`, `mise run vet`, `mise run test` (all pass; config coverage 94.7%), `mise run lint` (0 issues).
- `e2e` build-tagged suite compiles cleanly (it binds the health server on a dynamic port, so it is unaffected).
- No Helm chart exists in this repo, so no chart/helm-docs/helm-unittest changes were required.
