### PR TITLE
Revert "feat: move the metrics/health server to 8081"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Configure `--domain-filter` (and its variants) on the **ExternalDNS controller**
 | `SERVER_IDLE_TIMEOUT`        | Keep-alive idle timeout.                                   | `120s`            |
 | `SERVER_MAX_HEADER_BYTES`    | Maximum request header size.                               | `65536`           |
 | `SERVER_MAX_BODY_BYTES`      | Maximum POST body size before returning `413`.             | `5242880` (5 MiB) |
-| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `0.0.0.0:8081`    |
+| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `0.0.0.0:8080`    |
 | `READINESS_CACHE_TTL`        | How long `/readyz` caches the upstream probe result.       | `30s`             |
 | `PPROF_ENABLED`              | Mount `/debug/pprof/*` on the health server (not in prod). | `false`           |
 | `LOG_LEVEL`                  | Log verbosity: `debug`, `info`, `warn`, `error`.           | `info`            |
@@ -171,10 +171,10 @@ Configure `--domain-filter` (and its variants) on the **ExternalDNS controller**
 | --------------- | -------------- | ----------------------------------------------------------- |
 | `/`             | `8888`         | ExternalDNS negotiate (returns the provider media type).    |
 | `/records`      | `8888`         | ExternalDNS `GET` (list) and `POST` (apply changes).        |
-| `/healthz`      | `8888`, `8081` | Liveness — `200 OK` while the process is running.           |
-| `/readyz`       | `8888`, `8081` | Readiness — probes UniFi, cached for `READINESS_CACHE_TTL`. |
-| `/metrics`      | `8081`         | Prometheus metrics.                                         |
-| `/debug/pprof/` | `8081`         | Go pprof endpoints (only when `PPROF_ENABLED=true`).        |
+| `/healthz`      | `8888`, `8080` | Liveness — `200 OK` while the process is running.           |
+| `/readyz`       | `8888`, `8080` | Readiness — probes UniFi, cached for `READINESS_CACHE_TTL`. |
+| `/metrics`      | `8080`         | Prometheus metrics.                                         |
+| `/debug/pprof/` | `8080`         | Go pprof endpoints (only when `PPROF_ENABLED=true`).        |
 
 `/healthz` and `/readyz` are served on both ports so Kubernetes probes can target the webhook port directly without exposing a second container port through the chart.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	ServerIdleTimeout       time.Duration `env:"SERVER_IDLE_TIMEOUT"        envDefault:"120s"`
 	ServerMaxHeaderBytes    int           `env:"SERVER_MAX_HEADER_BYTES"    envDefault:"65536"`
 	ServerMaxBodyBytes      int64         `env:"SERVER_MAX_BODY_BYTES"      envDefault:"5242880"`
-	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:"0.0.0.0:8081"`
+	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:"0.0.0.0:8080"`
 	ReadinessCacheTTL       time.Duration `env:"READINESS_CACHE_TTL"        envDefault:"30s"`
 	PprofEnabled            bool          `env:"PPROF_ENABLED"              envDefault:"false"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,7 @@ func validConfig() Config {
 		ServerMaxBodyBytes:   5 << 20,
 		ServerMaxHeaderBytes: 1 << 16,
 		ServerReadTimeout:    60 * time.Second,
-		HealthServerAddr:     "0.0.0.0:8081",
+		HealthServerAddr:     "0.0.0.0:8080",
 	}
 }
 
@@ -60,8 +60,8 @@ func TestInit_Defaults(t *testing.T) {
 	if cfg.ServerPort != 8888 {
 		t.Errorf("ServerPort = %d, want 8888", cfg.ServerPort)
 	}
-	if cfg.HealthServerAddr != "0.0.0.0:8081" {
-		t.Errorf("HealthServerAddr = %q, want 0.0.0.0:8081", cfg.HealthServerAddr)
+	if cfg.HealthServerAddr != "0.0.0.0:8080" {
+		t.Errorf("HealthServerAddr = %q, want 0.0.0.0:8080", cfg.HealthServerAddr)
 	}
 }
 


### PR DESCRIPTION
Reverts home-operations/external-dns-unifi-webhook#254