### PR TITLE
chore(renovate): inherit shared toolchain group preset

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,15 +2,4 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
-  packageRules: [
-    {
-      description: "Go Toolchain Group",
-      matchManagers: ["mise", "gomod"],
-      matchDepNames: ["go"],
-      matchFileNames: [".mise/config.toml", "go.mod"],
-      groupName: "Go toolchain",
-      groupSlug: "go-toolchain",
-      minimumGroupSize: 2,
-    },
-  ],
 }


### PR DESCRIPTION
Now that home-operations/renovate-config#25 is merged, `external-dns-unifi-webhook` inherits the shared `groups.json5`
(toolchain grouping) and `helmPostUpgradeTasks.json5` (chart-doc regen) presets via its existing
`extends: ["local>home-operations/renovate-config"]`.

Removes the now-redundant local config:
- the local toolchain group packageRule(s)

Pure deletion — behavior unchanged:
- `packageRules` merge additively, so the inherited toolchain group is identical to the removed local copy.

Part of the org consolidation Tier-1 rollout.
