### PR TITLE
fix(unifi): drop redundant instrumented HTTP client causing unbounded path-cardinality metric

### DIFF
--- a/internal/unifi/client.go
+++ b/internal/unifi/client.go
@@ -95,13 +95,18 @@ func newUnifiClient(config *Config) (*httpClient, error) {
 		return nil, err
 	}
 
-	// NewInstrumentedClient wraps the transport so every outbound call emits
-	// external_dns_http_request_duration_seconds, matching the metric naming
-	// the rest of the external-dns ecosystem (and the inbound webhook server)
-	// uses. See sigs.k8s.io/external-dns PR #6307.
+	// Do NOT wrap with extdnshttp.NewInstrumentedClient here. Its
+	// external_dns_http_request_duration_seconds metric is labelled by the
+	// request path, and the UniFi Integration API embeds the per-record UUID in
+	// the path (.../dns/policies/{uuid}). Every record ever touched then becomes
+	// a permanent series, so the metric grows unbounded (tens of thousands of
+	// series for a few dozen records) until the /metrics payload blows past a
+	// scraper's max-scrape-size and scraping breaks entirely. UniFi API timing
+	// is already covered, with bounded operation labels, by
+	// externaldns_webhook_unifi_api_duration_seconds (see RecordUniFiAPICall).
 	c := &httpClient{
 		cfg:   config,
-		httpc: extdnshttp.NewInstrumentedClient(&http.Client{Transport: transport}),
+		httpc: &http.Client{Transport: transport},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), siteResolveTimeoutFor(config))


### PR DESCRIPTION
## Problem

`newUnifiClient` wraps the UniFi API HTTP client with `extdnshttp.NewInstrumentedClient`, which emits `external_dns_http_request_duration_seconds` labelled by request `path`. The UniFi Integration API embeds the per-record UUID in the path (`.../dns/policies/{uuid}`), so **every DNS record ever created or deleted becomes a permanent time series**.

This is effectively unbounded: records get deleted and recreated with fresh UUIDs over time, so the series count only grows. In a small homelab this reached **~26,000 series for a few dozen real records**, producing a **~25 MB `/metrics` payload** on the webhook port.

Once that payload crosses a scraper's max-scrape-size (16 MB by default in Prometheus/VictoriaMetrics), scraping the endpoint **fails completely** — you lose *all* webhook metrics, not just the noisy one:

```
cannot scrape target ".../metrics" ... the uncompressed response ... exceeds
-promscrape.maxScrapeSize or max_scrape_size in the scrape config (16777216 bytes)
```

## Fix

Drop the `NewInstrumentedClient` wrapper and use a plain `&http.Client{Transport: transport}`.

UniFi API timing is already recorded — with **bounded** labels (`provider`, `operation` ∈ {`get_endpoints`, `create_endpoint`, `delete_record`}) — by `externaldns_webhook_unifi_api_duration_seconds` via `RecordUniFiAPICall`. The instrumented wrapper was therefore redundant, and its only unique contribution was the unbounded-cardinality metric. Removing it loses no observability while eliminating the failure mode.

`extdnshttp` is still imported and used for `DrainAndClose`.

## Testing

- `go build ./...` — clean
- `go test ./...` — all pass
