### PR TITLE
fix(unifi): don't treat a CNAME update as a conflict; count final-attempt 429s

### DIFF
--- a/internal/server/readiness.go
+++ b/internal/server/readiness.go
@@ -17,7 +17,13 @@ type ProbeFunc func(ctx context.Context) error
 // detached from any caller's request context (see Check), so it needs its own
 // ceiling — without one a hung upstream connection (the UniFi client sets no
 // overall http.Client timeout, relying on ctx) would block the singleflight
-// slot forever. Generous enough to absorb the client's default retry budget.
+// slot forever.
+//
+// Deliberately NOT sized to the UniFi client's worst-case retry budget (which
+// Retry-After hints can stretch to tens of seconds): a controller deep in a
+// rate-limit or outage episode should read as not-ready rather than keep the
+// pod in rotation while a probe grinds through its full backoff schedule. The
+// next cached probe re-checks once the TTL lapses.
 const probeTimeout = 10 * time.Second
 
 // cachedProbe wraps a ProbeFunc with a TTL-bounded result cache and

--- a/internal/unifi/provider.go
+++ b/internal/unifi/provider.go
@@ -180,13 +180,27 @@ func (p *UnifiProvider) ApplyChanges(ctx context.Context, changes *plan.Changes)
 		return err
 	}
 
+	// Keys the delete phase just processed. The snapshot index still lists their
+	// (now removed) record IDs, so the CNAME-conflict cleanup below must skip
+	// them: a routine CNAME *update* (UpdateOld+UpdateNew for the same name) is
+	// not a conflict, and re-deleting the stale IDs would only burn an API round
+	// trip per record (the 404s are tolerated) and false-positive the conflict
+	// metric on every CNAME target change.
+	deletedKeys := make(map[recordKey]struct{}, len(deleteEPs))
+	for _, ep := range deleteEPs {
+		deletedKeys[recordKey{ep.DNSName, ep.RecordType}] = struct{}{}
+	}
+
 	createEPs := slices.Concat(changes.Create, changes.UpdateNew)
 	if err := runBounded(ctx, p.workers, createEPs, func(ctx context.Context, ep *endpoint.Endpoint) error {
 		if ep.RecordType == recordTypeCNAME {
-			if ids := byKeyType[recordKey{ep.DNSName, recordTypeCNAME}]; len(ids) > 0 {
-				m.CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName).Inc()
-				if err := p.deleteByIDs(ctx, ids); err != nil {
-					return fmt.Errorf("deleting conflicting CNAME %s: %w", ep.DNSName, err)
+			key := recordKey{ep.DNSName, recordTypeCNAME}
+			if _, handled := deletedKeys[key]; !handled {
+				if ids := byKeyType[key]; len(ids) > 0 {
+					m.CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName).Inc()
+					if err := p.deleteByIDs(ctx, ids); err != nil {
+						return fmt.Errorf("deleting conflicting CNAME %s: %w", ep.DNSName, err)
+					}
 				}
 			}
 		}

--- a/internal/unifi/provider_test.go
+++ b/internal/unifi/provider_test.go
@@ -321,3 +321,70 @@ func TestAdjustEndpoints_ClearsTTLForControllerManagedTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestApplyChanges_CNAMEUpdateIsNotAConflict: a routine CNAME update
+// (UpdateOld+UpdateNew for the same name) must delete the old record exactly
+// once — in the delete phase — and must NOT take the conflict-cleanup branch.
+// Before the deletedKeys guard, the create phase re-read the pre-delete
+// snapshot, counted a spurious CNAME conflict, and issued a second DELETE that
+// 404ed on every CNAME target change.
+func TestApplyChanges_CNAMEUpdateIsNotAConflict(t *testing.T) {
+	var deleteCount, notFoundServed atomic.Int32
+	existing := []dnsPolicyEnvelope{
+		envCNAME("old-cname", "alias.example.com", "old.target.example.com", 300),
+	}
+	var deletedOnce atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(pageOf(existing...))
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		case http.MethodDelete:
+			deleteCount.Add(1)
+			if !deletedOnce.CompareAndSwap(false, true) {
+				// The record is already gone — a second DELETE is the bug.
+				notFoundServed.Add(1)
+				w.WriteHeader(http.StatusNotFound)
+
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	conflicts := metrics.Get().CNAMEConflictsTotal.WithLabelValues(metrics.ProviderName)
+	readConflicts := func() float64 {
+		t.Helper()
+		var m dto.Metric
+		if err := conflicts.Write(&m); err != nil {
+			t.Fatalf("counter.Write: %v", err)
+		}
+
+		return m.GetCounter().GetValue()
+	}
+	before := readConflicts()
+
+	p := &UnifiProvider{client: newTestClient(srv), workers: 1}
+	changes := &plan.Changes{
+		UpdateOld: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("alias.example.com", "CNAME", 300, "old.target.example.com")},
+		UpdateNew: []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("alias.example.com", "CNAME", 300, "new.target.example.com")},
+	}
+	if err := p.ApplyChanges(context.Background(), changes); err != nil {
+		t.Fatalf("ApplyChanges: %v", err)
+	}
+
+	if got := deleteCount.Load(); got != 1 {
+		t.Errorf("DELETE count = %d, want 1 (the update's own delete; no redundant conflict cleanup)", got)
+	}
+	if got := notFoundServed.Load(); got != 0 {
+		t.Errorf("served %d 404s — the stale snapshot was re-deleted", got)
+	}
+	if got := readConflicts() - before; got != 0 {
+		t.Errorf("CNAMEConflictsTotal delta = %v, want 0 (an update is not a conflict)", got)
+	}
+}

--- a/internal/unifi/transport.go
+++ b/internal/unifi/transport.go
@@ -49,6 +49,11 @@ func newHTTPTransport(cfg *Config) (*http.Transport, error) {
 		// expose the API key to a trivial MITM, so we never honour it.
 		slog.Warn("ignoring UNIFI_SKIP_TLS_VERIFY for the cloud connector; api.ui.com presents a publicly-trusted certificate")
 	case cfg.SkipTLSVerify:
+		// The other branches warn when they *override* the operator's setting;
+		// this one warns because verification is genuinely off (the default, for
+		// self-signed controllers) — operators should see that in the log and
+		// know UNIFI_CA_CERT is the way to keep TLS verified.
+		slog.Warn("TLS certificate verification is disabled (UNIFI_SKIP_TLS_VERIFY); set UNIFI_CA_CERT to verify a self-signed controller")
 		//nolint:gosec // Explicit opt-in via UNIFI_SKIP_TLS_VERIFY for self-signed controllers.
 		tlsCfg.InsecureSkipVerify = true
 	}
@@ -74,8 +79,9 @@ func newHTTPTransport(cfg *Config) (*http.Transport, error) {
 func (c *httpClient) doRequest(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
 	attempts := max(c.cfg.RetryAttempts, 1)
 
-	var lastErr error
-	for attempt := range attempts {
+	// The final attempt always returns inside the loop (the give-up branch
+	// covers attempt == attempts-1), so the loop itself needs no exit condition.
+	for attempt := 0; ; attempt++ {
 		if attempt > 0 {
 			if err := ctx.Err(); err != nil {
 				return nil, err
@@ -85,6 +91,14 @@ func (c *httpClient) doRequest(ctx context.Context, method, path string, body []
 		resp, err := c.doOnce(ctx, method, path, body)
 		if err == nil && resp.StatusCode < 400 {
 			return resp, nil
+		}
+
+		// Count every 429 the controller sends, whether or not we retry it —
+		// the metric promises "rate-limit responses received", and the final
+		// attempt's 429 (or the only one, with UNIFI_RETRY_ATTEMPTS=1) is the
+		// one that actually fails the operation.
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			metrics.Get().UniFiRateLimitsTotal.WithLabelValues(metrics.ProviderName, opLabel(path)).Inc()
 		}
 
 		retryable, wait := c.retryAfter(method, resp, err, attempt)
@@ -106,9 +120,6 @@ func (c *httpClient) doRequest(ctx context.Context, method, path string, body []
 		status := "network"
 		if resp != nil {
 			status = strconv.Itoa(resp.StatusCode)
-			if resp.StatusCode == http.StatusTooManyRequests {
-				metrics.Get().UniFiRateLimitsTotal.WithLabelValues(metrics.ProviderName, opLabel(path)).Inc()
-			}
 		}
 		metrics.Get().UniFiRetriesTotal.WithLabelValues(metrics.ProviderName, opLabel(path), status).Inc()
 		slog.Debug("retrying upstream request", "attempt", attempt+1, "wait", wait, "status", status)
@@ -118,10 +129,7 @@ func (c *httpClient) doRequest(ctx context.Context, method, path string, body []
 			return nil, ctx.Err()
 		case <-time.After(wait):
 		}
-		lastErr = err
 	}
-
-	return nil, lastErr
 }
 
 // doOnce performs a single request attempt. The caller decides whether to

--- a/internal/unifi/transport_test.go
+++ b/internal/unifi/transport_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/home-operations/external-dns-unifi-webhook/internal/metrics"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func newRetryClient(t *testing.T, srv *httptest.Server, cfg *Config) *httpClient {
@@ -413,5 +414,39 @@ func TestDoRequest_NetworkErrorRetries(t *testing.T) {
 	var netErr *NetworkError
 	if !errors.As(err, &netErr) {
 		t.Errorf("expected NetworkError, got %T: %v", err, err)
+	}
+}
+
+// TestDoRequest_FinalAttempt429IsCounted: every 429 the controller sends must
+// increment the rate-limit counter — including the one on the final (or only)
+// attempt, which previously exited through the give-up branch uncounted. With
+// UNIFI_RETRY_ATTEMPTS=1, rate limits were never counted at all.
+func TestDoRequest_FinalAttempt429IsCounted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	rateLimits := metrics.Get().UniFiRateLimitsTotal.WithLabelValues(metrics.ProviderName, "dns_policies")
+	read := func() float64 {
+		t.Helper()
+		var dm dto.Metric
+		if err := rateLimits.Write(&dm); err != nil {
+			t.Fatalf("counter.Write: %v", err)
+		}
+
+		return dm.GetCounter().GetValue()
+	}
+	before := read()
+
+	c := newRetryClient(t, srv, &Config{RetryAttempts: 1})
+	_, err := c.doRequest(context.Background(), http.MethodGet,
+		srv.URL+"/proxy/network/integration/v1/sites/x/dns/policies", nil)
+	if err == nil {
+		t.Fatal("expected an error from an all-429 upstream")
+	}
+
+	if got := read() - before; got != 1 {
+		t.Errorf("rate-limit counter delta = %v, want 1 (the final attempt's 429 must be counted)", got)
 	}
 }

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -46,6 +46,7 @@ func (p *Webhook) Records(w http.ResponseWriter, r *http.Request) {
 	records, err := p.provider.Records(r.Context())
 	if err != nil {
 		requestLog(r).Error("getting records", "error", err)
+		w.Header().Set(contentTypeHeader, contentTypePlaintext)
 		w.WriteHeader(http.StatusInternalServerError)
 
 		return


### PR DESCRIPTION
## What

Two confirmed bugs from a project review, plus small polish riding along.

| # | Bug | Fix |
|---|-----|-----|
| 1 | **Every CNAME update fired the conflict-cleanup branch.** `ApplyChanges`' create phase consults the record index snapshotted *before* the delete phase ran, so an `UpdateOld`+`UpdateNew` pair for the same name found its own just-deleted record IDs: `unifi_cname_conflicts_total` incremented (a routine target change is not a conflict — anyone alerting on it gets a false positive per CNAME change) and a **second DELETE** was issued per record, answered 404 and tolerated. Verified against a mock controller: 2 DELETEs, 1 × 404, per update. | The create phase skips conflict cleanup for keys the delete phase handled this reconcile (`deletedKeys`, derived from the change list — no shared-state races). A genuine conflict (a `Create` landing on an unmanaged existing CNAME) still cleans up and counts; the existing `TestApplyChanges_CNAMEConflictUsesSnapshot` guards that path. |
| 2 | **`unifi_api_rate_limits_total` undercounted 429s.** The counter only incremented in the *retry* branch, so the final attempt's 429 — the one that actually fails the operation — was never counted, and with `UNIFI_RETRY_ATTEMPTS=1` rate limits were **never** counted. The help text promises "rate-limit responses received". | Count the 429 where it is observed, before the retry/give-up decision. |

## Polish (same review)

- **Warn when TLS verification is actually disabled** — the CA-override and cloud branches already warn; the branch that turns verification off (the default, for self-signed controllers) was silent. One `slog.Warn` pointing at `UNIFI_CA_CERT`.
- **`probeTimeout` comment corrected** — it claimed to be "generous enough to absorb the client's default retry budget", but the worst case (Retry-After-driven) is ~2× the timeout. The behaviour is deliberate and now documented as such: a controller deep in a rate-limit episode should read not-ready rather than hold the pod in rotation while a probe grinds through backoff.
- **Dead code removed** — `doRequest`'s trailing `return nil, lastErr` was unreachable (the final attempt always returns inside the loop); the loop is now `for attempt := 0; ; attempt++` and the `lastErr` bookkeeping is gone.
- **`Records` 500 sets `Content-Type`** like the other handlers.

## Tests

`TestApplyChanges_CNAMEUpdateIsNotAConflict` (exactly 1 DELETE, zero 404s, zero conflict-counter delta — fails pre-fix with 2 DELETEs / 1 × 404 / +1 conflict) and `TestDoRequest_FinalAttempt429IsCounted` (`RetryAttempts=1`, all-429 upstream → counter delta 1 — was 0 pre-fix).

Verified: `go test -race ./...`, `vet`, `lint` (0).
