### PR TITLE
fix: bind the health server dual-stack by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Configure `--domain-filter` (and its variants) on the **ExternalDNS controller**
 | `SERVER_IDLE_TIMEOUT`        | Keep-alive idle timeout.                                   | `120s`            |
 | `SERVER_MAX_HEADER_BYTES`    | Maximum request header size.                               | `65536`           |
 | `SERVER_MAX_BODY_BYTES`      | Maximum POST body size before returning `413`.             | `5242880` (5 MiB) |
-| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `0.0.0.0:8080`    |
+| `HEALTH_SERVER_ADDR`         | Address for the `/metrics`, `/healthz`, `/readyz` server.  | `:8080`           |
 | `READINESS_CACHE_TTL`        | How long `/readyz` caches the upstream probe result.       | `30s`             |
 | `PPROF_ENABLED`              | Mount `/debug/pprof/*` on the health server (not in prod). | `false`           |
 | `LOG_LEVEL`                  | Log verbosity: `debug`, `info`, `warn`, `error`.           | `info`            |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	ServerIdleTimeout       time.Duration `env:"SERVER_IDLE_TIMEOUT"        envDefault:"120s"`
 	ServerMaxHeaderBytes    int           `env:"SERVER_MAX_HEADER_BYTES"    envDefault:"65536"`
 	ServerMaxBodyBytes      int64         `env:"SERVER_MAX_BODY_BYTES"      envDefault:"5242880"`
-	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:"0.0.0.0:8080"`
+	HealthServerAddr        string        `env:"HEALTH_SERVER_ADDR"         envDefault:":8080"`
 	ReadinessCacheTTL       time.Duration `env:"READINESS_CACHE_TTL"        envDefault:"30s"`
 	PprofEnabled            bool          `env:"PPROF_ENABLED"              envDefault:"false"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,7 +13,7 @@ func validConfig() Config {
 		ServerMaxBodyBytes:   5 << 20,
 		ServerMaxHeaderBytes: 1 << 16,
 		ServerReadTimeout:    60 * time.Second,
-		HealthServerAddr:     "0.0.0.0:8080",
+		HealthServerAddr:     ":8080",
 	}
 }
 
@@ -60,8 +60,8 @@ func TestInit_Defaults(t *testing.T) {
 	if cfg.ServerPort != 8888 {
 		t.Errorf("ServerPort = %d, want 8888", cfg.ServerPort)
 	}
-	if cfg.HealthServerAddr != "0.0.0.0:8080" {
-		t.Errorf("HealthServerAddr = %q, want 0.0.0.0:8080", cfg.HealthServerAddr)
+	if cfg.HealthServerAddr != ":8080" {
+		t.Errorf("HealthServerAddr = %q, want :8080", cfg.HealthServerAddr)
 	}
 }
 


### PR DESCRIPTION
`HEALTH_SERVER_ADDR` defaulted to `0.0.0.0:8080` — an IPv4-only wildcard, so the `/healthz`, `/readyz`, and `/metrics` listener never comes up reachable on IPv6-only clusters. An empty host (`:8080`) binds the unspecified address dual-stack (works on v4-only, v6-only, and dual-stack alike).

Ports themselves stay frozen (external-dns webhook-provider chart contract: webhook 8888, health 8080). Setting `HEALTH_SERVER_ADDR=0.0.0.0:8080` explicitly still works for anyone who wants the old behavior.

Closes out the org port-standard rollout for this repo. Verified: build, full test suite, golangci-lint clean.