### PR TITLE
fix(go): update to go 1.27.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 actionlint = "1.7.12"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.0"
 lefthook = "2.1.10"
 oxfmt = "0.63.0"
 zizmor = "1.29.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -23,45 +23,45 @@ url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/3849248
 provenance = "github-attestations"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.golangci-lint]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
+checksum = "sha256:3a91c7bb9c135099a97858bea431d6dd2f54e4bf68d479c776c2350428d60e41"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471362"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
+checksum = "sha256:a10e8d8359d76b9e2b41da60f9d98bb26fd53c7a453caa82e0a172d6f72fd2ca"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471346"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools.lefthook]]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/external-dns-unifi-webhook
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1

--- a/internal/unifi/errors_test.go
+++ b/internal/unifi/errors_test.go
@@ -408,8 +408,7 @@ func TestErrorChaining(t *testing.T) {
 	wrappedTwice := fmt.Errorf("second wrap: %w", wrappedOnce)
 
 	// Should still be detectable as DataError through multiple wraps.
-	var target *DataError
-	if !errors.As(wrappedTwice, &target) {
+	if _, ok := errors.AsType[*DataError](wrappedTwice); !ok {
 		t.Error("errors.As failed to detect DataError through multiple wraps")
 	}
 

--- a/internal/unifi/transport_test.go
+++ b/internal/unifi/transport_test.go
@@ -411,8 +411,7 @@ func TestDoRequest_NetworkErrorRetries(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error against closed server")
 	}
-	var netErr *NetworkError
-	if !errors.As(err, &netErr) {
+	if _, ok := errors.AsType[*NetworkError](err); !ok {
 		t.Errorf("expected NetworkError, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
Updates the toolchain to Go 1.27.0 and runs the `go fix` modernizers. Same rollout as home-operations/echo#84, home-operations/gatus-sidecar#177, and home-operations/containers#1777.

- Bump `go` to 1.27.0 in mise and go.mod, lockfile regenerated.
- Bump golangci-lint 2.12.2 → 2.13.0: 2.12.2 is built with go1.26 and refuses a 1.27 language target; 2.13.0 is built with go1.27.0.
- Apply the `errors.AsType` fixer from `go fix`: two test-only `errors.As` calls whose target variable was otherwise unused become `errors.AsType[T]`. Note `errors.AsType` is a Go 1.26 API — this fired because it's the first `go fix` pass over the repo, not because of 1.27. The remaining `errors.As` sites pre-seed and then read the target, so the fixer correctly leaves them.

Verified locally: `go build`, `go vet`, `gofmt -l` (clean), `golangci-lint run` (0 issues), `go test -race ./...` (all pass), `govulncheck` (clean).